### PR TITLE
Refactor/core/presigned url

### DIFF
--- a/.github/commit_template.txt
+++ b/.github/commit_template.txt
@@ -1,4 +1,4 @@
-:# Commit Convention
+# Commit Convention
 # ✨ feat     : 새로운 기능 추가
 # 🐛 fix      : 버그 수정
 # 💡 chore    : 기능 추가 없이 코드 수정 (오타, 주석 등)

--- a/apps/core/tests/test_s3_urls.py
+++ b/apps/core/tests/test_s3_urls.py
@@ -4,84 +4,89 @@ from moto import mock_aws
 from apps.core.utils.s3_urls import s3
 
 
-class TestS3Urls(TestCase):
+class TestS3Handler(TestCase):
     def setUp(self) -> None:
-        self.file = "test_file"
-        self.suffix = ".jpg"
         self.file_name = "test_file.jpg"
         self.path = "test/"
-        self.content_type = "image/jpeg"
 
-    # 파일명이 빈 문자열일 경우 예외처리가 되는지
-    def test_suffix_blank_file_name(self) -> None:
-        file_name = ""
-        with self.assertRaises(ValueError):
-            s3._suffix(file_name)
+        self.key, self.content_type = s3._key_and_type(self.file_name, self.path)
 
     # 확장자가 없는 경우 예외처리가 되는지
     def test_suffix_blank_suffix(self) -> None:
-        with self.assertRaises(ValueError):
-            s3._suffix(self.file)
+        file_name = "test_file"
+        with self.assertRaises(ValueError) as e:
+            s3._suffix(file_name)
+        self.assertEqual(str(e.exception), "지원하지 않는 파일 형식입니다.")
 
     # 화이트리스트에 없는 확장자가 들어온 경우 예외처리가 되는지
     def test_suffix_invalid_suffix(self) -> None:
-        invalid_file_name = "test_file.test"
-        with self.assertRaises(ValueError):
-            s3._suffix(invalid_file_name)
+        file_name = "test_file.test"
+        with self.assertRaises(ValueError) as e:
+            s3._suffix(file_name)
+        self.assertEqual(str(e.exception), "지원하지 않는 파일 형식입니다.")
+
+    # 대문자 확장자를 넣어도 소문자로 통일이 되는지
+    def test_suffix_lowercase(self) -> None:
+        file_name = "test_file.JPG"
+        self.assertEqual(s3._suffix(file_name), ".jpg")
 
     # 화이트리스트에 등록된 확장자가 들어온 경우 의도한 값을 반환을 하는지
     def test_suffix_valid_suffix(self) -> None:
-        self.assertEqual(s3._suffix(self.file_name), (".jpg", "image/jpeg"))
+        self.assertEqual(s3._suffix(self.file_name), ".jpg")
+
+    # add_name을 넣었을 때 uuid가 의도한대로 생성되는지
+    def test_uuid_add_name(self) -> None:
+        uuid = s3._image_uuid(add_name="cat")
+        self.assertEqual(len(uuid), 40)
+        self.assertTrue(uuid.endswith("_cat"))
 
     # path 마지막에 슬래시가 있어도 key가 의도한대로 생성되는지
     def test_key_path_with_slash(self) -> None:
-        key = s3._key(self.path, self.suffix)
-        self.assertNotIn("//", key)
-        self.assertEqual(key[:5], "test/")
-        self.assertEqual(key[-4:], ".jpg")
+        self.assertNotIn("//", self.key)
+        self.assertTrue(self.key.startswith("test/"))
+        self.assertTrue(self.key.endswith(".jpg"))
 
     # path 마지막에 슬래시가 없어도 key가 의도한대로 생성되는지
     def test_key_path_without_slash(self) -> None:
         path = "test"
-        key = s3._key(path, self.suffix)
+        key, _ = s3._key_and_type(self.file_name, path)
         self.assertNotIn("//", key)
-        self.assertEqual(key[:5], "test/")
-        self.assertEqual(key[-4:], ".jpg")
+        self.assertTrue(key.startswith("test/"))
+        self.assertTrue(key.endswith(".jpg"))
 
-    # add_name을 넣었을 때 key가 의도한대로 생성되는지
-    def test_key_add_name(self) -> None:
-        key = s3._key(self.path, self.suffix, "cat")
-        self.assertEqual(key[-8:], "_cat.jpg")
+    # content_type이 의도한대로 생성되는지
+    def test_content_type(self) -> None:
+        self.assertEqual(self.content_type, "image/jpeg")
 
     # img_url이 잘 생성되는지
     def test_img_url(self) -> None:
-        key = s3._key(self.path, self.suffix)
-        img_url = s3._img_url(key)
-        self.assertEqual(img_url, f"https://{s3.bucket}.s3.{s3.region}.amazonaws.com/{key}")
+        img_url = s3._img_url(self.key)
+        self.assertEqual(img_url, f"https://{s3.bucket}.s3.{s3.region}.amazonaws.com/{self.key}")
 
     # img_url이 255자 이내인지. 테스트의 img_url에선 99자
     def test_img_url_length(self) -> None:
-        key = s3._key(self.path, self.suffix)
-        img_url = s3._img_url(key)
+        img_url = s3._img_url(self.key)
         self.assertLessEqual(len(img_url), 255)
+
+    # s3.create_img_url이 잘 작동하는지
+    def test_create_img_url(self) -> None:
+        img_url = s3.create_img_url(self.file_name, self.path)
+        self.assertTrue(img_url.startswith("https://"))
 
     # presigned_url이 잘 생성되는지
     @mock_aws
-    def test_upload_presigned_url(self) -> None:
-        key = s3._key(self.path, self.suffix)
-        presigned_url = s3._upload_presigned_url(key, self.content_type)
+    def test_presigned_url_for_upload(self) -> None:
+        presigned_url = s3._presigned_url_for_upload(self.key, self.content_type)
         self.assertEqual(presigned_url.count("?"), 1)
         self.assertTrue(presigned_url.startswith("https://"))
-        self.assertIn(key, presigned_url)
+        self.assertIn(self.key, presigned_url)
         self.assertIn("X-Amz-Signature", presigned_url)
         self.assertIn("X-Amz-Credential", presigned_url)
         self.assertIn("X-Amz-Algorithm", presigned_url)
         self.assertIn("X-Amz-Expires=600", presigned_url)
 
-    # s3.create_upload_urls()가 잘 나오는지
+    # s3.create_upload_urls()가 잘 작동하는지
     @mock_aws
-    def test_create_upload_urls(self) -> None:
-        presigned_url, img_url = s3.create_upload_urls(self.file_name, self.path)
+    def test_create_presigned_url(self) -> None:
+        presigned_url = s3.create_presigned_url(self.file_name, self.path)
         self.assertTrue(presigned_url.startswith("https://"))
-        self.assertTrue(img_url.startswith("https://"))
-        self.assertNotEqual(presigned_url, img_url)

--- a/apps/core/utils/s3_urls.py
+++ b/apps/core/utils/s3_urls.py
@@ -46,7 +46,7 @@ class S3Handler:
         add_name: 파일명을 uuid_cat.png처럼 만들고 싶다면, add_name에 cat을 넣어주면 됩니다
         """
 
-        key, content_type = self._key_and_type(path, file_name, add_name)
+        key, content_type = self._key_and_type(file_name, path, add_name)
         presigned_url = self._presigned_url_for_upload(key, content_type, expire)
 
         return presigned_url
@@ -57,13 +57,13 @@ class S3Handler:
         파라미터에 대한 설명은 create_presigned_url() 참고
         """
 
-        key, _ = self._key_and_type(path, file_name, add_name)
+        key, _ = self._key_and_type(file_name, path, add_name)
         img_url = self._img_url(key)
 
         return img_url
 
     # key: 파일명을 포함한 저장경로. ex) uploads/images/questions/uuid.png
-    def _key_and_type(self, path: str, file_name: str, add_name: str | None = None) -> tuple[str, str]:
+    def _key_and_type(self, file_name: str, path: str, add_name: str | None = None) -> tuple[str, str]:
         suffix = self._suffix(file_name)
         key = path.rstrip("/") + "/" + self._image_uuid(add_name) + suffix
         content_type = self.ALLOWED_SUFFIX[suffix]

--- a/apps/core/utils/s3_urls.py
+++ b/apps/core/utils/s3_urls.py
@@ -3,8 +3,11 @@
 
 from apps.core.utils.s3_urls import s3
 위에서처럼 임포트해서 쓰세요
-s3.create_upload_urls()을 사용해서 presigned_url과 img_url을 생성하세요
-파라미터에 대한 설명은 create_upload_urls() 내부에 있습니다
+
+presigned_url 생성: s3.create_presigned_url()
+img_url 생성: s3.create_img_url()
+
+파라미터에 대한 설명은 create_presigned_url() 내부에 있습니다
 """
 
 import uuid
@@ -33,10 +36,8 @@ class S3Handler:
         self.bucket = settings.AWS_S3_BUCKET_NAME
         self.region = settings.AWS_S3_REGION
 
-    # presigned url과 img_url 2개를 반환하는 함수
-    def create_upload_urls(
-        self, file_name: str, path: str, expire: int = 600, *, add_name: str | None = None
-    ) -> tuple[str, str]:
+    # presigned url을 반환하는 함수
+    def create_presigned_url(self, file_name: str, path: str, expire: int = 600, *, add_name: str | None = None) -> str:
         """
         file_name: 확장자를 포함한 파일명을 그대로 넣어주세요
         path: 저장경로에서 파일명을 뺀 값. 저장경로가 uploads/images/questions/uuid.png라면
@@ -45,43 +46,49 @@ class S3Handler:
         add_name: 파일명을 uuid_cat.png처럼 만들고 싶다면, add_name에 cat을 넣어주면 됩니다
         """
 
-        suffix, content_type = self._suffix(file_name)
+        key, content_type = self._key_and_type(path, file_name, add_name)
+        presigned_url = self._presigned_url_for_upload(key, content_type, expire)
 
-        key = self._key(path, suffix, add_name)
+        return presigned_url
 
-        presigned_url = self._upload_presigned_url(key, content_type, expire)
+    # img_url을 반환하는 함수
+    def create_img_url(self, file_name: str, path: str, *, add_name: str | None = None) -> str:
+        """
+        파라미터에 대한 설명은 create_presigned_url() 참고
+        """
 
+        key, _ = self._key_and_type(path, file_name, add_name)
         img_url = self._img_url(key)
 
-        return presigned_url, img_url
+        return img_url
 
-    # 확장자 분리, 확장자 화이트 리스트
+    # key: 파일명을 포함한 저장경로. ex) uploads/images/questions/uuid.png
+    def _key_and_type(self, path: str, file_name: str, add_name: str | None = None) -> tuple[str, str]:
+        suffix = self._suffix(file_name)
+        key = path.rstrip("/") + "/" + self._image_uuid(add_name) + suffix
+        content_type = self.ALLOWED_SUFFIX[suffix]
+
+        return key, content_type
+
+    # 파일명에서 확장자 분리, 확장자 화이트 리스트
     @classmethod
-    def _suffix(cls, file_name: str) -> tuple[str, str]:
+    def _suffix(cls, file_name: str) -> str:
         suffix = Path(file_name).suffix.lower()
 
         if suffix not in cls.ALLOWED_SUFFIX:
             raise ValueError("지원하지 않는 파일 형식입니다.")
 
-        content_type = cls.ALLOWED_SUFFIX[suffix]
+        return suffix
 
-        return suffix, content_type
-
-    # 키: 파일명을 포함한 저장경로. ex) uploads/images/questions/uuid.png
-    def _key(self, path: str, suffix: str, add_name: str | None = None) -> str:
-        key = path.rstrip("/") + "/" + self._image_uuid(add_name) + suffix
-
-        return key
-
-    # 파일명 생성 함수
+    # uuid 파일명 생성 함수
     @staticmethod
-    def _image_uuid(add_name: str | None) -> str:
+    def _image_uuid(add_name: str | None = None) -> str:
         add = f"_{add_name}" if add_name else ""
 
         return str(uuid.uuid4()) + add
 
     # 업로드용 presigned url 생성 함수
-    def _upload_presigned_url(self, key: str, content_type: str, expire: int = 600) -> str:
+    def _presigned_url_for_upload(self, key: str, content_type: str, expire: int = 600) -> str:
         presigned_url = self.s3.generate_presigned_url(
             ClientMethod="put_object",
             Params={


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: s3_urls.py파일 리펙터링

## 📄 상세 내용
- ~~img_url이 DB에 저장되는 시점이 클라이언트의 업로드가 완료된 시점일 거 같아서 presigned_url 생성과 분리함~~
- ~~이에 대한 테스트 코드도 함께 리펙터링~~
- 분리하면 uuid 가 달라져서 안될 듯

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
