### PR TITLE
✨ feat: 댓글 목록 조회, 작성, 삭제 API 구현

### DIFF
--- a/apps/posts/exceptions.py
+++ b/apps/posts/exceptions.py
@@ -8,3 +8,7 @@ class PostPermissionDeniedError(Exception):
 
 class CommentNotFoundError(Exception):
     pass
+
+
+class CommentPermissionDeniedError(Exception):
+    pass

--- a/apps/posts/serializers/__init__.py
+++ b/apps/posts/serializers/__init__.py
@@ -1,0 +1,4 @@
+from apps.posts.serializers.comment import (
+    CommentCreateSerializer,
+    PostCommentSerializer,
+)

--- a/apps/posts/serializers/comment.py
+++ b/apps/posts/serializers/comment.py
@@ -1,0 +1,44 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.posts.models.comment import PostComment
+
+
+class CommentAuthorSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    nickname = serializers.CharField()
+    profile_img_url = serializers.CharField(allow_null=True)
+
+
+class TaggedUserSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    nickname = serializers.CharField()
+
+
+class PostCommentSerializer(serializers.ModelSerializer[PostComment]):
+    author = CommentAuthorSerializer(read_only=True)
+    tagged_users = serializers.SerializerMethodField()
+
+    class Meta:
+        model = PostComment
+        fields = ["id", "author", "tagged_users", "content", "created_at"]
+
+    def get_tagged_users(self, obj: PostComment) -> Any:
+        tags = obj.tags.all()
+        return TaggedUserSerializer([tag.tagged_user for tag in tags], many=True).data
+
+
+class CommentCreateSerializer(serializers.ModelSerializer[PostComment]):
+    tagged_user_ids = serializers.ListField(
+        child=serializers.IntegerField(), required=False, default=list, write_only=True
+    )
+
+    class Meta:
+        model = PostComment
+        fields = ["content", "tagged_user_ids"]
+
+    def validate_content(self, value: str) -> str:
+        if not value.strip():
+            raise serializers.ValidationError("댓글 내용을 입력해주세요.")
+        return value

--- a/apps/posts/services/__init__.py
+++ b/apps/posts/services/__init__.py
@@ -1,0 +1,1 @@
+from apps.posts.services.comment import create_comment, delete_comment, get_comments

--- a/apps/posts/services/comment.py
+++ b/apps/posts/services/comment.py
@@ -1,0 +1,38 @@
+from django.db.models import QuerySet
+
+from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError
+from apps.posts.models.comment import PostComment, PostCommentTag
+from apps.users.models import User
+
+
+def get_comments(post_id: int, page: int, page_size: int) -> tuple[int, QuerySet["PostComment"]]:
+    offset = (page - 1) * page_size
+
+    qs = PostComment.objects.filter(post_id=post_id).select_related("author").prefetch_related("tags__tagged_user")
+
+    total_count = qs.count()
+    comments = qs[offset : offset + page_size]
+
+    return total_count, comments
+
+
+def create_comment(user: User, post_id: int, content: str, tagged_user_ids: list[int]) -> PostComment:
+    comment = PostComment.objects.create(author=user, post_id=post_id, content=content)
+
+    if tagged_user_ids:
+        PostCommentTag.objects.bulk_create(
+            [PostCommentTag(comment=comment, tagged_user_id=uid) for uid in tagged_user_ids], ignore_conflicts=True
+        )
+    return PostComment.objects.select_related("author").prefetch_related("tags__tagged_user").get(id=comment.id)
+
+
+def delete_comment(user: User, comment_id: int, post_id: int) -> None:
+    try:
+        comment = PostComment.objects.get(id=comment_id, post_id=post_id)
+    except PostComment.DoesNotExist:
+        raise CommentNotFoundError("해당 댓글을 찾을 수 없습니다.")
+
+    if comment.author_id != user.id:
+        raise CommentPermissionDeniedError("권한이 없습니다.")
+
+    comment.delete()

--- a/apps/posts/services/comment.py
+++ b/apps/posts/services/comment.py
@@ -1,11 +1,22 @@
+from django.db import transaction
 from django.db.models import QuerySet
 
-from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError
+from apps.posts.exceptions import (
+    CommentNotFoundError,
+    CommentPermissionDeniedError,
+    PostNotFoundError,
+)
 from apps.posts.models.comment import PostComment, PostCommentTag
+from apps.posts.models.post import Post
 from apps.users.models import User
 
 
 def get_comments(post_id: int, page: int, page_size: int) -> tuple[int, QuerySet["PostComment"]]:
+    if not Post.objects.filter(id=post_id).exists():
+        raise PostNotFoundError("해당 게시글을 찾을 수 없습니다.")
+
+    page = max(page, 1)
+    page_size = max(page_size, 1)
     offset = (page - 1) * page_size
 
     qs = PostComment.objects.filter(post_id=post_id).select_related("author").prefetch_related("tags__tagged_user")
@@ -16,13 +27,18 @@ def get_comments(post_id: int, page: int, page_size: int) -> tuple[int, QuerySet
     return total_count, comments
 
 
+@transaction.atomic
 def create_comment(user: User, post_id: int, content: str, tagged_user_ids: list[int]) -> PostComment:
+    if not Post.objects.filter(id=post_id).exists():
+        raise PostNotFoundError("해당 게시글을 찾을 수 없습니다.")
+
     comment = PostComment.objects.create(author=user, post_id=post_id, content=content)
 
     if tagged_user_ids:
         PostCommentTag.objects.bulk_create(
             [PostCommentTag(comment=comment, tagged_user_id=uid) for uid in tagged_user_ids], ignore_conflicts=True
         )
+
     return PostComment.objects.select_related("author").prefetch_related("tags__tagged_user").get(id=comment.id)
 
 

--- a/apps/posts/tests/test_comment.py
+++ b/apps/posts/tests/test_comment.py
@@ -1,0 +1,204 @@
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.core.utils.test_factories import create_test_user
+from apps.posts.models import Post, PostCategory, PostComment, PostCommentTag
+from apps.users.models import User
+
+
+class CommentBaseTest(APITestCase):
+    author: User
+    other: User
+    post: Post
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.author = create_test_user("author")
+        cls.other = create_test_user("other")
+        category = PostCategory.objects.create(name="자유")
+        cls.post = Post.objects.create(
+            author=cls.author,
+            category=category,
+            title="테스트 게시글",
+            content="테스트 내용",
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+
+class CommentListCreateViewGetTest(CommentBaseTest):
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.url = reverse("comment_list_create", kwargs={"post_id": cls.post.id})
+
+    def test_get_comments_success(self) -> None:
+        PostComment.objects.create(author=self.author, post=self.post, content="댓글 1")
+        PostComment.objects.create(author=self.author, post=self.post, content="댓글 2")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertEqual(len(response.data["results"]), 2)
+
+    def test_get_comments_post_not_found(self) -> None:
+        url = reverse("comment_list_create", kwargs={"post_id": 99999})
+
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error_detail"], "해당 게시글을 찾을 수 없습니다.")
+
+    def test_get_comments_empty(self) -> None:
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(len(response.data["results"]), 0)
+
+    def test_get_comments_pagination(self) -> None:
+        for i in range(15):
+            PostComment.objects.create(author=self.author, post=self.post, content=f"댓글 {i}")
+
+        response = self.client.get(self.url, {"page": 1, "page_size": 10})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 15)
+        self.assertEqual(len(response.data["results"]), 10)
+        self.assertIsNotNone(response.data["next"])
+        self.assertIsNone(response.data["previous"])
+
+    def test_get_comments_unauthenticated_success(self) -> None:
+        PostComment.objects.create(author=self.author, post=self.post, content="댓글")
+
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class CommentListCreateViewPostTest(CommentBaseTest):
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.url = reverse("comment_list_create", kwargs={"post_id": cls.post.id})
+
+    def test_create_comment_success(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        payload = {"content": "테스트 댓글"}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertEqual(response.data["detail"], "댓글이 등록되었습니다.")
+        comment = PostComment.objects.filter(post=self.post).first()
+        assert comment is not None
+        self.assertEqual(comment.author, self.author)
+        self.assertEqual(comment.content, "테스트 댓글")
+
+    def test_create_comment_with_tag_success(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        tagged_user = create_test_user("tagged")
+        payload = {
+            "content": f"@{tagged_user.nickname} 태그 테스트",
+            "tagged_user_ids": [tagged_user.id],
+        }
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        tag = PostCommentTag.objects.filter(tagged_user=tagged_user).first()
+        assert tag is not None
+        self.assertEqual(tag.tagged_user, tagged_user)
+
+    def test_create_comment_missing_content(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        payload = {}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+        self.assertIn("content", response.data["error_detail"])
+
+    def test_create_comment_blank_content(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        payload = {"content": "  "}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_create_comment_unauthenticated_unauthorized(self) -> None:
+        payload = {"content": "테스트 댓글"}
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_create_comment_post_not_found(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        url = reverse("comment_list_create", kwargs={"post_id": 99999})
+        payload = {"content": "테스트 댓글"}
+
+        response = self.client.post(url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error_detail"], "해당 게시글을 찾을 수 없습니다.")
+
+
+class CommentDetailViewDeleteTest(CommentBaseTest):
+    comment: PostComment
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.comment = PostComment.objects.create(
+            author=cls.author,
+            post=cls.post,
+            content="삭제될 댓글"
+        )
+        cls.url = reverse("comment_detail", kwargs={"post_id": cls.post.id, "comment_id": cls.comment.id})
+
+    def test_delete_comment_success(self) -> None:
+        self.client.force_authenticate(user=self.author)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "댓글이 삭제되었습니다.")
+        self.assertFalse(PostComment.objects.filter(id=self.comment.id).exists())
+
+    def test_delete_comment_not_author_forbidden(self) -> None:
+        self.client.force_authenticate(user=self.other)
+
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data["error_detail"], "권한이 없습니다.")
+        self.assertTrue(PostComment.objects.filter(id=self.comment.id).exists())
+
+    def test_delete_comment_unauthenticated_unauthorized(self) -> None:
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertTrue(PostComment.objects.filter(id=self.comment.id).exists())
+
+    def test_delete_comment_not_found(self) -> None:
+        self.client.force_authenticate(user=self.author)
+        url = reverse("comment_detail", kwargs={"post_id": self.post.id, "comment_id": 99999})
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data["error_detail"], "해당 댓글을 찾을 수 없습니다.")

--- a/apps/posts/tests/test_comment.py
+++ b/apps/posts/tests/test_comment.py
@@ -35,18 +35,17 @@ class CommentListCreateViewGetTest(CommentBaseTest):
     def setUpTestData(cls) -> None:
         super().setUpTestData()
         cls.url = reverse("comment_list_create", kwargs={"post_id": cls.post.id})
+        for i in range(1, 16):
+            PostComment.objects.create(author=cls.author, post=cls.post, content=f"댓글{i}")
 
     def test_get_comments_success(self) -> None:
-        PostComment.objects.create(author=self.author, post=self.post, content="댓글 1")
-        PostComment.objects.create(author=self.author, post=self.post, content="댓글 2")
-
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 2)
+        self.assertEqual(response.data["count"], 15)
         self.assertIn("next", response.data)
         self.assertIn("previous", response.data)
-        self.assertEqual(len(response.data["results"]), 2)
+        self.assertEqual(len(response.data["results"]), 10)
 
     def test_get_comments_post_not_found(self) -> None:
         url = reverse("comment_list_create", kwargs={"post_id": 99999})
@@ -56,17 +55,7 @@ class CommentListCreateViewGetTest(CommentBaseTest):
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
         self.assertEqual(response.data["error_detail"], "해당 게시글을 찾을 수 없습니다.")
 
-    def test_get_comments_empty(self) -> None:
-        response = self.client.get(self.url)
-
-        self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data["count"], 0)
-        self.assertEqual(len(response.data["results"]), 0)
-
     def test_get_comments_pagination(self) -> None:
-        for i in range(15):
-            PostComment.objects.create(author=self.author, post=self.post, content=f"댓글 {i}")
-
         response = self.client.get(self.url, {"page": 1, "page_size": 10})
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
@@ -76,11 +65,25 @@ class CommentListCreateViewGetTest(CommentBaseTest):
         self.assertIsNone(response.data["previous"])
 
     def test_get_comments_unauthenticated_success(self) -> None:
-        PostComment.objects.create(author=self.author, post=self.post, content="댓글")
-
         response = self.client.get(self.url)
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+
+class CommentListCreateViewGetEmptyTest(CommentBaseTest):
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        super().setUpTestData()
+        cls.url = reverse("comment_list_create", kwargs={"post_id": cls.post.id})
+
+    def test_get_comments_empty(self) -> None:
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(len(response.data["results"]), 0)
 
 
 class CommentListCreateViewPostTest(CommentBaseTest):
@@ -121,7 +124,7 @@ class CommentListCreateViewPostTest(CommentBaseTest):
 
     def test_create_comment_missing_content(self) -> None:
         self.client.force_authenticate(user=self.author)
-        payload = {}
+        payload: dict[str, object] = {}
 
         response = self.client.post(self.url, payload, format="json")
 
@@ -160,15 +163,14 @@ class CommentDetailViewDeleteTest(CommentBaseTest):
     comment: PostComment
     url: str
 
-    @classmethod
-    def setUpTestData(cls) -> None:
-        super().setUpTestData()
-        cls.comment = PostComment.objects.create(
-            author=cls.author,
-            post=cls.post,
-            content="삭제될 댓글"
+    def setUp(self) -> None:
+        super().setUp()
+        self.comment = PostComment.objects.create(
+            author=self.author,
+            post=self.post,
+            content="삭제될 댓글",
         )
-        cls.url = reverse("comment_detail", kwargs={"post_id": cls.post.id, "comment_id": cls.comment.id})
+        self.url = reverse("comment_detail", kwargs={"post_id": self.post.id, "comment_id": self.comment.id})
 
     def test_delete_comment_success(self) -> None:
         self.client.force_authenticate(user=self.author)

--- a/apps/posts/urls/__init__.py
+++ b/apps/posts/urls/__init__.py
@@ -2,4 +2,5 @@ from django.urls import URLPattern, URLResolver, include, path
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path("", include("apps.posts.urls.post_crud")),
+    path("", include("apps.posts.urls.comment")),
 ]

--- a/apps/posts/urls/comment.py
+++ b/apps/posts/urls/comment.py
@@ -1,0 +1,8 @@
+from django.urls import path
+
+from apps.posts.views.comment import CommentDetailView, CommentListCreateView
+
+urlpatterns = [
+    path("<int:post_id>/comments/", CommentListCreateView.as_view()),
+    path("<int:post_id>/comments/<int:comment_id>/", CommentDetailView.as_view()),
+]

--- a/apps/posts/urls/comment.py
+++ b/apps/posts/urls/comment.py
@@ -3,6 +3,6 @@ from django.urls import path
 from apps.posts.views.comment import CommentDetailView, CommentListCreateView
 
 urlpatterns = [
-    path("<int:post_id>/comments/", CommentListCreateView.as_view()),
-    path("<int:post_id>/comments/<int:comment_id>/", CommentDetailView.as_view()),
+    path("<int:post_id>/comments/", CommentListCreateView.as_view(), name="comment_list_create"),
+    path("<int:post_id>/comments/<int:comment_id>/", CommentDetailView.as_view(), name="comment_detail"),
 ]

--- a/apps/posts/views/__init__.py
+++ b/apps/posts/views/__init__.py
@@ -1,0 +1,1 @@
+from apps.posts.views.comment import CommentDetailView, CommentListCreateView

--- a/apps/posts/views/comment.py
+++ b/apps/posts/views/comment.py
@@ -1,4 +1,4 @@
-from typing import cast
+from typing import Never, cast
 
 from drf_spectacular.utils import extend_schema
 from rest_framework import exceptions, status
@@ -7,7 +7,11 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError, PostNotFoundError
+from apps.posts.exceptions import (
+    CommentNotFoundError,
+    CommentPermissionDeniedError,
+    PostNotFoundError,
+)
 from apps.posts.serializers.comment import (
     CommentCreateSerializer,
     PostCommentSerializer,
@@ -19,7 +23,7 @@ from apps.users.models import User
 class CommentListCreateView(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
-    def permission_denied(self, request, message=None, code=None):
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
         if not request.successful_authenticator:
             raise exceptions.NotAuthenticated(detail="자격 인증 데이터가 제공되지 않았습니다.", code=code)
         raise exceptions.PermissionDenied(detail="권한이 없습니다.", code=code)
@@ -82,7 +86,7 @@ class CommentListCreateView(APIView):
 class CommentDetailView(APIView):
     permission_classes = [IsAuthenticated]
 
-    def permission_denied(self, request, message=None, code=None):
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
         if not request.successful_authenticator:
             raise exceptions.NotAuthenticated(detail="자격 인증 데이터가 제공되지 않았습니다.", code=code)
         raise exceptions.PermissionDenied(detail="권한이 없습니다.", code=code)

--- a/apps/posts/views/comment.py
+++ b/apps/posts/views/comment.py
@@ -1,0 +1,90 @@
+from typing import cast
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError
+from apps.posts.models.post import Post
+from apps.posts.serializers.comment import (
+    CommentCreateSerializer,
+    PostCommentSerializer,
+)
+from apps.posts.services import comment as comment_service
+from apps.users.models import User
+
+
+class CommentListCreateView(APIView):
+    permission_classes = [IsAuthenticatedOrReadOnly]
+
+    @extend_schema(
+        tags=["comments"],
+        summary="댓글 목록 조회",
+        responses={200: PostCommentSerializer(many=True), 404: None},
+    )
+    def get(self, request: Request, post_id: int) -> Response:
+        if not Post.objects.filter(id=post_id).exists():
+            return Response({"error_detail": "해당 게시글을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        page = int(request.query_params.get("page", 1))
+        page_size = int(request.query_params.get("page_size", 10))
+
+        total_count, comments = comment_service.get_comments(post_id, page, page_size)
+
+        base_url = request.build_absolute_uri(request.path)
+        next_page = f"{base_url}?page={page + 1}&page_size={page_size}" if (page * page_size) < total_count else None
+        previous_page = f"{base_url}?page={page - 1}&page_size={page_size}" if page > 1 else None
+
+        return Response(
+            {
+                "count": total_count,
+                "next": next_page,
+                "previous": previous_page,
+                "results": PostCommentSerializer(comments, many=True).data,
+            }
+        )
+
+    @extend_schema(
+        tags=["comments"],
+        summary="댓글 작성",
+        request=CommentCreateSerializer,
+        responses={201: None, 400: None, 401: None, 404: None},
+    )
+    def post(self, request: Request, post_id: int) -> Response:
+        if not Post.objects.filter(id=post_id).exists():
+            return Response({"error_detail": "해당 게시글을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = CommentCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        comment_service.create_comment(
+            user=cast(User, request.user),
+            post_id=post_id,
+            content=serializer.validated_data["content"],
+            tagged_user_ids=serializer.validated_data.get("tagged_user_ids", []),
+        )
+
+        return Response({"detail": "댓글이 등록되었습니다."}, status=status.HTTP_201_CREATED)
+
+
+class CommentDetailView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["comments"],
+        summary="댓글 삭제",
+        responses={200: None, 401: None, 403: None, 404: None},
+    )
+    def delete(self, request: Request, post_id: int, comment_id: int) -> Response:
+        try:
+            comment_service.delete_comment(user=cast(User, request.user), comment_id=comment_id, post_id=post_id)
+        except CommentNotFoundError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except CommentPermissionDeniedError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_403_FORBIDDEN)
+
+        return Response({"detail": "댓글이 삭제되었습니다."}, status=status.HTTP_200_OK)

--- a/apps/posts/views/comment.py
+++ b/apps/posts/views/comment.py
@@ -1,14 +1,13 @@
 from typing import cast
 
 from drf_spectacular.utils import extend_schema
-from rest_framework import status
+from rest_framework import exceptions, status
 from rest_framework.permissions import IsAuthenticated, IsAuthenticatedOrReadOnly
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError
-from apps.posts.models.post import Post
+from apps.posts.exceptions import CommentNotFoundError, CommentPermissionDeniedError, PostNotFoundError
 from apps.posts.serializers.comment import (
     CommentCreateSerializer,
     PostCommentSerializer,
@@ -20,21 +19,31 @@ from apps.users.models import User
 class CommentListCreateView(APIView):
     permission_classes = [IsAuthenticatedOrReadOnly]
 
+    def permission_denied(self, request, message=None, code=None):
+        if not request.successful_authenticator:
+            raise exceptions.NotAuthenticated(detail="자격 인증 데이터가 제공되지 않았습니다.", code=code)
+        raise exceptions.PermissionDenied(detail="권한이 없습니다.", code=code)
+
     @extend_schema(
         tags=["comments"],
         summary="댓글 목록 조회",
         responses={200: PostCommentSerializer(many=True), 404: None},
     )
     def get(self, request: Request, post_id: int) -> Response:
-        if not Post.objects.filter(id=post_id).exists():
-            return Response({"error_detail": "해당 게시글을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
-
         page = int(request.query_params.get("page", 1))
         page_size = int(request.query_params.get("page_size", 10))
 
-        total_count, comments = comment_service.get_comments(post_id, page, page_size)
+        try:
+            total_count, comments = comment_service.get_comments(
+                post_id=post_id,
+                page=page,
+                page_size=page_size,
+            )
+        except PostNotFoundError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
         base_url = request.build_absolute_uri(request.path)
+
         next_page = f"{base_url}?page={page + 1}&page_size={page_size}" if (page * page_size) < total_count else None
         previous_page = f"{base_url}?page={page - 1}&page_size={page_size}" if page > 1 else None
 
@@ -54,25 +63,29 @@ class CommentListCreateView(APIView):
         responses={201: None, 400: None, 401: None, 404: None},
     )
     def post(self, request: Request, post_id: int) -> Response:
-        if not Post.objects.filter(id=post_id).exists():
-            return Response({"error_detail": "해당 게시글을 찾을 수 없습니다."}, status=status.HTTP_404_NOT_FOUND)
-
         serializer = CommentCreateSerializer(data=request.data)
         if not serializer.is_valid():
             return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
-
-        comment_service.create_comment(
-            user=cast(User, request.user),
-            post_id=post_id,
-            content=serializer.validated_data["content"],
-            tagged_user_ids=serializer.validated_data.get("tagged_user_ids", []),
-        )
+        try:
+            comment_service.create_comment(
+                user=cast(User, request.user),
+                post_id=post_id,
+                content=serializer.validated_data["content"],
+                tagged_user_ids=serializer.validated_data.get("tagged_user_ids", []),
+            )
+        except PostNotFoundError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
 
         return Response({"detail": "댓글이 등록되었습니다."}, status=status.HTTP_201_CREATED)
 
 
 class CommentDetailView(APIView):
     permission_classes = [IsAuthenticated]
+
+    def permission_denied(self, request, message=None, code=None):
+        if not request.successful_authenticator:
+            raise exceptions.NotAuthenticated(detail="자격 인증 데이터가 제공되지 않았습니다.", code=code)
+        raise exceptions.PermissionDenied(detail="권한이 없습니다.", code=code)
 
     @extend_schema(
         tags=["comments"],


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [ ] CommentListCreateView: 댓글 목록 조회(GET), 댓글 작성(POST) / 조회는 모두, 작성은 로그인 한 유저만
- [ ] CommentDetailView: 댓글 삭제(DELETE) / 로그인 한 댓글 작성자만 삭제가 가능
- [ ] PostCommentSerializer, CommentCreateSerializer 추가 / 댓글 목록 조회 시 작성자 정보, 태그된 유저목록
- [ ] get_comments, create_comment, delete_comment 서비스 추가 / 특정 게시글의 댓글을 페이지네이션으로 조회, 댓글 생성 후 유저 태그 저장, 중복 태그 무시, 작성자 확인 후 삭제, 없는 댓글이면 404, 권한 없으면 403 커스텀에러 적용

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
