### PR TITLE
refactor(posts): Like model 상속 TimeStampModel

### DIFF
--- a/apps/posts/models/like.py
+++ b/apps/posts/models/like.py
@@ -1,8 +1,10 @@
 from django.conf import settings
 from django.db import models
 
+from apps.core.models import TimeStampModel
 
-class Like(models.Model):
+
+class Like(TimeStampModel):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,
         on_delete=models.CASCADE,
@@ -14,8 +16,6 @@ class Like(models.Model):
         related_name="likes",
     )
     is_liked = models.BooleanField(default=True)
-    created_at = models.DateTimeField(auto_now_add=True)
-    updated_at = models.DateTimeField(auto_now=True)
 
     class Meta:
         db_table = "post_likes"


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: `Post` **Like** 모델이 프로젝트 공통 `TimeStampModel`을 상속하도록 정리 후 migrate
                       DB 스키마는 기존과 동일하므로 **새 마이그레이션 파일은 추가하지 않습니다.**

## 📄 상세 내용
- [x] `Like`를 `models.Model` + 수동 `DateTimeField` 대신 `TimeStampModel` 상속으로 변경
- [x] `TimeStampModel`이 제공하는 `created_at`(`auto_now_add=True`), `updated_at`(`auto_now=True`)와 기존 `0005_like` 마이그레이션에 정의된 컬럼이 동일하여 **스키마 변경 없음** → `makemigrations`에 새 항목 없음
- [x] `Meta.ordering`의 `-created_at` 등 기존 동작은 그대로 유지

## 📸 스크린샷 (선택)
- 해당 없음

## 📝 기타 참고 사항
- `TimeStampModel`은 `abstract = True`이므로 별도 부모 테이블이 생기지 않고, `post_likes` 테이블의 `created_at` / `updated_at`은 기존과 동일합니다.
- 로컬/스테이징에서 적용은 기존 migration(`0005_like` 등)이 이미 반영된 상태에서 `migrate`만 수행하면 됩니다. **이 PR만으로는 새 `*.py` migration이 추가되지 않을 수 있습니다.**

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
  - `poetry run isort . --check --diff` / `poetry run black . --check` / `poetry run mypy .` 후 PR
  - Docker  `manage.py migrate` 로그에 `No migrations to apply` 및 앱 기동 정상 여부 확인함