### PR TITLE
feat: 게시글 좋아요 등록 및 취소 API 구현

### DIFF
--- a/apps/posts/exceptions.py
+++ b/apps/posts/exceptions.py
@@ -8,3 +8,15 @@ class PostPermissionDeniedError(Exception):
 
 class CommentNotFoundError(Exception):
     pass
+
+
+class PostLikePostNotFoundError(Exception):
+    pass
+
+
+class PostAlreadyLikedError(Exception):
+    pass
+
+
+class PostLikeNotRegisteredError(Exception):
+    pass

--- a/apps/posts/serializers/like.py
+++ b/apps/posts/serializers/like.py
@@ -1,0 +1,15 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class PostLikeCreateResponseSerializer(serializers.Serializer[dict[str, Any]]):
+    detail = serializers.CharField(default="좋아요가 등록되었습니다.")
+
+
+class PostLikeCancelResponseSerializer(serializers.Serializer[dict[str, Any]]):
+    detail = serializers.CharField(default="좋아요가 취소되었습니다.")
+
+
+class PostLikeErrorResponseSerializer(serializers.Serializer[dict[str, Any]]):
+    error_detail = serializers.CharField()

--- a/apps/posts/services/like.py
+++ b/apps/posts/services/like.py
@@ -1,0 +1,49 @@
+from apps.posts.exceptions import (
+    PostAlreadyLikedError,
+    PostLikeNotRegisteredError,
+    PostLikePostNotFoundError,
+)
+from apps.posts.models import Like, Post
+from apps.users.models import User
+
+
+def get_visible_post_or_raise(post_id: int) -> Post:
+    post = Post.objects.filter(id=post_id, is_visible=True).first()
+    if post is None:
+        raise PostLikePostNotFoundError("해당 게시글을 찾을 수 없습니다.")
+    return post
+
+
+def create_post_like(user: User, post_id: int) -> Like:
+    post = get_visible_post_or_raise(post_id)
+    like, created = Like.objects.get_or_create(
+        user=user,
+        post=post,
+        defaults={"is_liked": True},
+    )
+
+    if created:
+        return like
+
+    if like.is_liked:
+        raise PostAlreadyLikedError("이미 좋아요를 누른 게시글입니다.")
+
+    like.is_liked = True
+    like.save(update_fields=["is_liked", "updated_at"])
+
+    return like
+
+
+def cancel_post_like(user: User, post_id: int) -> None:
+    post = get_visible_post_or_raise(post_id)
+
+    like = Like.objects.filter(
+        user=user,
+        post=post,
+    ).first()
+
+    if like is None or not like.is_liked:
+        raise PostLikeNotRegisteredError("좋아요 기록을 찾을 수 없습니다.")
+
+    like.is_liked = False
+    like.save(update_fields=["is_liked", "updated_at"])

--- a/apps/posts/urls/__init__.py
+++ b/apps/posts/urls/__init__.py
@@ -2,4 +2,5 @@ from django.urls import URLPattern, URLResolver, include, path
 
 urlpatterns: list[URLPattern | URLResolver] = [
     path("", include("apps.posts.urls.post_crud")),
+    path("", include("apps.posts.urls.like")),
 ]

--- a/apps/posts/urls/like.py
+++ b/apps/posts/urls/like.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.posts.views.like import PostLikeView
+
+urlpatterns = [
+    path("<int:post_id>/like", PostLikeView.as_view(), name="post-like"),
+]

--- a/apps/posts/views/like.py
+++ b/apps/posts/views/like.py
@@ -1,0 +1,92 @@
+from typing import NoReturn, cast
+
+from drf_spectacular.utils import extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.posts.exceptions import (
+    PostAlreadyLikedError,
+    PostLikeNotRegisteredError,
+    PostLikePostNotFoundError,
+)
+from apps.posts.serializers.like import (
+    PostLikeCancelResponseSerializer,
+    PostLikeCreateResponseSerializer,
+    PostLikeErrorResponseSerializer,
+)
+from apps.posts.services.like import cancel_post_like, create_post_like
+from apps.users.models import User
+
+
+class PostLikeView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    def permission_denied(
+        self,
+        request: Request,
+        message: str | None = None,
+        code: str | None = None,
+    ) -> NoReturn:
+        raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+
+    @extend_schema(
+        tags=["posts"],
+        summary="게시글 좋아요 생성",
+        description="게시글 좋아요를 생성하거나 취소된 좋아요를 다시 활성화",
+        responses={
+            201: PostLikeCreateResponseSerializer,
+            401: PostLikeErrorResponseSerializer,
+            404: PostLikeErrorResponseSerializer,
+            409: PostLikeErrorResponseSerializer,
+        },
+    )
+    def post(self, request: Request, post_id: int) -> Response:
+        try:
+            create_post_like(
+                user=cast(User, request.user),
+                post_id=post_id,
+            )
+        except PostLikePostNotFoundError as e:
+            return Response(
+                {"error_detail": str(e)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        except PostAlreadyLikedError as e:
+            return Response(
+                {"error_detail": str(e)},
+                status=status.HTTP_409_CONFLICT,
+            )
+        return Response(
+            {"detail": "좋아요가 등록되었습니다."},
+            status=status.HTTP_201_CREATED,
+        )
+
+    @extend_schema(
+        tags=["posts"],
+        summary="게시글 좋아요 취소",
+        description="게시글 좋아요를 취소합니다. 단, row를 삭제하지 않고 is_liked 필드를 False로 변경합니다.",
+        responses={
+            200: PostLikeCancelResponseSerializer,
+            401: PostLikeErrorResponseSerializer,
+            404: PostLikeErrorResponseSerializer,
+        },
+    )
+    def delete(self, request: Request, post_id: int) -> Response:
+        try:
+            cancel_post_like(
+                user=cast(User, request.user),
+                post_id=post_id,
+            )
+        except (PostLikePostNotFoundError, PostLikeNotRegisteredError) as e:
+            return Response(
+                {"error_detail": str(e)},
+                status=status.HTTP_404_NOT_FOUND,
+            )
+        return Response(
+            {"detail": "좋아요가 취소되었습니다."},
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 게시글 좋아요 등록 및 취소 API를 구현했습니다.

## 📄 상세 내용
- [x] 게시글 좋아요 등록 API를 추가했습니다.
- [x] 게시글 좋아요 취소 API를 추가했습니다.
- [x] 좋아요 관련 View, Service, Serializer, URL, 예외 클래스를 추가했습니다.
- [x] 이미 좋아요한 게시글, 좋아요 기록이 없는 게시글, 존재하지 않는 게시글에 대한 예외 응답을 처리했습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- 게시글 목록/상세 응답의 `like_count` 반영은 게시글 조회 API 담당에게 전달하도록 하겠습니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
