### PR TITLE
Feature/user info : 내 정보 수정 API 구현

### DIFF
--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -1,8 +1,14 @@
+import re
+from datetime import date
+from typing import cast
+
 from rest_framework import serializers
 
 from apps.users.models import User
+from apps.users.utils.user_exceptions import DuplicateNicknameError
 
 
+# 내 정보 조회
 class UserInfoSerializer(serializers.ModelSerializer[User]):
     # 수강생인 경우 보여줄 추가 필드
     cohort_id = serializers.SerializerMethodField()
@@ -31,25 +37,43 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
         return cohort_student.cohort.id
 
 
-# class UserInfoUpdateSerializer(serializers.ModelSerializer[User]):
-#     cohort_id = serializers.IntegerField(
-#         source="cohort_students.first.cohort.id",
-#         read_only=True,
-#         allow_null=True,
-#     )
-#
-#     class Meta:
-#         model = User
-#         fields = [
-#             "id",
-#             "email",
-#             "nickname",
-#             "name",
-#             "phone_number",
-#             "birthday",
-#             "gender",
-#             "profile_img_url",
-#             "cohort_id",
-#             "created_at",
-#         ]
-#         read_only_fields = fields
+# 내 정보 수정
+class UserInfoUpdateSerializer(serializers.ModelSerializer[User]):
+
+    class Meta:
+        model = User
+        fields = [
+            "nickname",
+            "name",
+            "birthday",
+            "gender",
+        ]
+
+    # 닉네임 정규식 & 중복 검사(exclude로 사용자가 원래 쓰던 닉네임 제외)
+    def validate_nickname(self, value: str) -> str:
+        if not re.match(r"^[가-힣a-zA-Z0-9]{2,10}$", value):
+            raise serializers.ValidationError("닉네임은 2~10자 이내, 특수문자 제외, 한글/영문/숫자만 허용됩니다.")
+        # mypy 걸려서 추가
+        instance = cast(User, self.instance)
+        if User.objects.filter(nickname=value).exclude(id=instance.id).exists():
+            raise DuplicateNicknameError()
+        return value
+
+    # 이름 정규식 검사(공백 허용)
+    def validate_name(self, value: str) -> str:
+        if not re.match(r"^[가-힣a-zA-Z\s]{1,30}$", value):
+            raise serializers.ValidationError("이름은1~30자 이내, 특수문자 제외, 한글/영문만 허용됩니다.")
+        return value
+
+    # 생일 검사(미래날짜 불가능하게)
+    def validate_birthday(self, value: date) -> date:
+        if value > date.today():
+            raise serializers.ValidationError("생일은 미래 날짜로 등록할 수 없습니다.")
+        return value
+
+
+class UserInfoUpdateResponseSerializer(serializers.ModelSerializer[User]):
+    class Meta:
+        model = User
+        fields = ["id", "email", "nickname", "name", "birthday", "gender", "phone_number", "updated_at"]
+        read_only_fields = fields

--- a/apps/users/tests/user_info_test.py
+++ b/apps/users/tests/user_info_test.py
@@ -1,4 +1,3 @@
-# apps/users/tests/test_user_info_view.py
 from datetime import date
 
 from django.urls import reverse
@@ -17,9 +16,10 @@ class UserInfoViewTest(APITestCase):
     cohort: Cohort
     url: str
 
+    # 내 정보 조회 테스트
     @classmethod
     def setUpTestData(cls) -> None:
-        cls.url = reverse("users:me")  # url name은 너 url 설정에 맞게 수정
+        cls.url = reverse("users:me")  # url name은 url 설정에 맞게 수정
 
         # 일반 유저 (수강생 등록 X)
         cls.user = User.objects.create_user(
@@ -126,3 +126,128 @@ class UserInfoViewTest(APITestCase):
         response = self.client.get(self.url)
 
         self.assertNotIn("password", response.data)
+
+    # 내 정보 수정 테스트
+    def test_patch_user_info_success(self) -> None:
+        """정상적인 정보 수정"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={
+                "nickname": "새닉네임",
+                "name": "새이름",
+                "birthday": "1990-01-01",
+                "gender": "F",
+            },
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # 응답 필드 검증 (명세서 응답 스키마)
+        data = response.data
+        self.assertEqual(data["nickname"], "새닉네임")
+        self.assertEqual(data["name"], "새이름")
+        self.assertEqual(data["birthday"], "1990-01-01")
+        self.assertEqual(data["gender"], "F")
+        self.assertIn("updated_at", data)
+
+        # DB 반영 확인
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.nickname, "새닉네임")
+        self.assertEqual(self.user.name, "새이름")
+
+    def test_patch_partial_update(self) -> None:
+        """일부 필드만 수정 - 나머지는 그대로"""
+        self.client.force_authenticate(user=self.user)
+        original_name = self.user.name
+
+        response = self.client.patch(
+            self.url,
+            data={"nickname": "닉네임만수정"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.nickname, "닉네임만수정")
+        self.assertEqual(self.user.name, original_name)
+
+    def test_patch_duplicate_nickname(self) -> None:
+        """다른 유저의 닉네임으로 변경 시 409"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"nickname": "수강닉"},  # student_user의 닉네임
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertIn("error_detail", response.data)
+        self.assertEqual(response.data["error_detail"], "중복된 닉네임이 존재합니다.")
+
+    def test_patch_same_nickname_allowed(self) -> None:
+        """본인 닉네임 그대로 보내도 통과"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"nickname": self.user.nickname},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_patch_invalid_nickname_format(self) -> None:
+        """닉네임 정규식 위반 (특수문자)"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"nickname": "닉@#$"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_invalid_name_format(self) -> None:
+        """이름 정규식 위반 (숫자 포함)"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"name": "이름123"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_future_birthday(self) -> None:
+        """미래 생일 차단"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"birthday": "2099-01-01"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_invalid_gender(self) -> None:
+        """잘못된 gender enum"""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.patch(
+            self.url,
+            data={"gender": "X"},  # M, F만 허용
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_patch_unauthenticated(self) -> None:
+        """비로그인 시 401"""
+        response = self.client.patch(
+            self.url,
+            data={"nickname": "새닉"},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertIn("error_detail", response.data)

--- a/apps/users/utils/user_exceptions.py
+++ b/apps/users/utils/user_exceptions.py
@@ -1,0 +1,13 @@
+from rest_framework.exceptions import APIException
+
+
+class NotAuthenticatedError(APIException):
+    status_code = 401
+    default_detail = "자격 인증 데이터가 제공되지 않았습니다."
+    default_code = "not_authenticated"
+
+
+class DuplicateNicknameError(APIException):
+    status_code = 409
+    default_detail = "중복된 닉네임이 존재합니다."
+    default_code = "duplicate_nickname"

--- a/apps/users/views/enrollment_view.py
+++ b/apps/users/views/enrollment_view.py
@@ -20,6 +20,7 @@ class EnrollmentView(APIView):
         raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
 
     @extend_schema(
+        tags=["Accounts (회원관리)"],
         summary="수강생 등록 신청 API",
         description="로그인한 유저만 과정과 기수를 선택하여 수강생 등록 신청할 수 있습니다",
         request=EnrollmentSerializer,

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -2,7 +2,6 @@ from typing import Never, cast
 
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
-from rest_framework.exceptions import NotAuthenticated, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -21,7 +20,7 @@ class UserInfoView(APIView):
     permission_classes = [IsAuthenticated]
 
     def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
-        raise NotAuthenticatedError
+        raise NotAuthenticatedError()
 
     @extend_schema(
         tags=["Accounts (회원관리)"],

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,6 +1,8 @@
 from typing import Never, cast
 
+from botocore.exceptions import ValidationError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
+from moto.dynamodb.models.dynamo_type import serializer
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.permissions import IsAuthenticated
@@ -9,16 +11,22 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.users.models import User
-from apps.users.serializers.user_info_serializer import UserInfoSerializer
+from apps.users.serializers.user_info_serializer import (
+    UserInfoSerializer,
+    UserInfoUpdateResponseSerializer,
+    UserInfoUpdateSerializer,
+)
+from apps.users.utils.user_exceptions import NotAuthenticatedError
 
 
 class UserInfoView(APIView):
     permission_classes = [IsAuthenticated]
 
     def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
-        raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise NotAuthenticatedError
 
     @extend_schema(
+        tags=["Accounts (회원관리)"],
         summary="내 정보 조회 API",
         description="로그인한 유저는 회원정보 조회가능, 수강생 등록이 되어있을 경우 수강중 과정, 기수도 조회가능",
         responses={
@@ -29,3 +37,24 @@ class UserInfoView(APIView):
     def get(self, request: Request) -> Response:
         serializer = UserInfoSerializer(cast(User, request.user))
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+    @extend_schema(
+        tags=["Accounts (회원관리)"],
+        summary="내 정보 수정 API",
+        description="로그인한 유저는 닉네임, 이름, 생년월일, 성별 수정 가능",
+        request=UserInfoUpdateSerializer,
+        responses={
+            200: UserInfoUpdateResponseSerializer,
+            400: OpenApiResponse(description="잘못된 요청"),
+            401: OpenApiResponse(description="인증 실패"),
+            409: OpenApiResponse(description="중복된 닉네임"),
+        },
+    )
+    def patch(self, request: Request) -> Response:
+        user = cast(User, request.user)
+        serializer = UserInfoUpdateSerializer(user, data=request.data, partial=True)
+        serializer.is_valid(raise_exception=True)
+        serializer.save()
+
+        response_serializer = UserInfoUpdateResponseSerializer(user)
+        return Response(response_serializer.data, status=status.HTTP_200_OK)

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,9 +1,8 @@
 from typing import Never, cast
 
-from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
-from rest_framework.exceptions import NotAuthenticated
+from rest_framework.exceptions import NotAuthenticated, ValidationError
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.request import Request
 from rest_framework.response import Response

--- a/apps/users/views/user_info_view.py
+++ b/apps/users/views/user_info_view.py
@@ -1,8 +1,7 @@
 from typing import Never, cast
 
-from botocore.exceptions import ValidationError
+from rest_framework.exceptions import ValidationError
 from drf_spectacular.utils import OpenApiResponse, extend_schema
-from moto.dynamodb.models.dynamo_type import serializer
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated
 from rest_framework.permissions import IsAuthenticated

--- a/config/urls.py
+++ b/config/urls.py
@@ -13,8 +13,6 @@ urlpatterns: list[URLPattern | URLResolver] = [
     path("api/v1/admin/qna/", include("apps.qna.urls.admin_urls")),
     path("api/v1/admin/exams/", include("apps.exams.admin_urls")),
     path("api/v1/accounts/", include("apps.users.urls", namespace="users")),
-    path("api/users/", include("apps.users.urls", namespace="users")),
-    path("api/v1/accounts/", include("apps.users.urls.account_url")),
     path("api/v1/exams/admin/", include("apps.exams.admin_urls")),
 ]
 


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [x] PATCH 메서드 추가 (PATCH /api/v1/accounts/me)
- [x] UserInfoUpdateSerializer 구현 (닉네임/이름 정규식, 닉네임 중복, 생일 미래날짜로 설정 불가능)
- [x] UserInfoUpdateResponseSerializer 구현 (수정 응답용)
- [x] user_exceptions.py 커스텀에러 파일 추가
- [x] 테스트 코드 작성

## 📸 스크린샷 (선택)
<img width="543" height="219" alt="스크린샷 2026-04-29 오후 2 00 54" src="https://github.com/user-attachments/assets/4a418650-0e37-468c-8c12-6092eff40407" />

## 📝 기타 참고 사항
- 닉네임 중복 검증 시 본인이 쓰던 닉네임은 제외 (exclude(id=instance.id))
- PATCH라 partial=True로 일부 필드만 수정 가능
- 생일 미래 차단은 데이터 정합성 차원에서 추가

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
