### PR TITLE
 💡 chore: 캐쉬키 수정

### DIFF
--- a/apps/users/services/auth_email_service.py
+++ b/apps/users/services/auth_email_service.py
@@ -39,7 +39,7 @@ class EmailVerificationService:
         # Base62 코드 생성
         code = Base62.uuid_encode(uuid.uuid4(), length=6)
         # Redis 저장
-        cache_key = f"email_code_{email}_{purpose.value}"  # type: ignore[misc]
+        cache_key = f"email_code_{email}"
         cache_data = {"code": code, "purpose": purpose.value}  # type: ignore[misc]
         # cache 저장 설정
         try:
@@ -74,7 +74,7 @@ class EmailVerificationService:
         :return: 인증 실패시 ValidationError 성공시  토큰 발급
         """
 
-        cache_key = f"email_code_{email}_{purpose.value}"  # type: ignore[misc]
+        cache_key = f"email_code_{email}"
         cached_data = cache.get(cache_key)
 
         if not cached_data:

--- a/apps/users/services/auth_sms_service.py
+++ b/apps/users/services/auth_sms_service.py
@@ -37,7 +37,7 @@ class SmsVerificationService:
             if not User.objects.filter(phone_number=phone_number).exists():
                 raise ValidationError("변경가능한 번호가 아닙니다")
 
-        cache_key = f"sms_code_{phone_number}_{purpose.value}"  # type: ignore[misc]
+        cache_key = f"sms_code_{phone_number}"
         # 캐시 저장 용도
         cache_data = {"purpose": purpose.value}  # type: ignore[misc]
         # cache 저장 설정
@@ -62,7 +62,7 @@ class SmsVerificationService:
         성공 시 다음 단계용 sms_token을 발급합니다.
         """
         formatted_phone = cls.phone_format_change(phone_number)
-        cache_key = f"sms_code_{phone_number}_{purpose.value}"  # type: ignore[misc]
+        cache_key = f"sms_code_{phone_number}"
         cached_data = cache.get(cache_key)
         if not cached_data:
             raise ValidationError("인증 코드가 만료되었거나 발급되지 않았습니다.")

--- a/apps/users/tests/test_auth_email.py
+++ b/apps/users/tests/test_auth_email.py
@@ -31,7 +31,7 @@ class EmailVerificationAPITests(IsolatedRedisTestClient):
         self.assertEqual(mail.outbox[0].to, [self.email])
 
         # 3. Redis 캐시에 코드가 잘 저장되었는지 확인
-        cache_key = f"email_code_{self.email}_{purpose}"
+        cache_key = f"email_code_{self.email}"
         cached_data = cache.get(cache_key)
         self.assertIsNotNone(cached_data)
         self.assertIn("code", cached_data)
@@ -61,7 +61,7 @@ class EmailVerificationAPITests(IsolatedRedisTestClient):
     def test_verify_email_signup_success(self) -> None:
         """[성공] 회원가입 용도"""
         purpose = "signup"
-        cache_key = f"email_code_{self.email}_{purpose}"
+        cache_key = f"email_code_{self.email}"
         cache.set(cache_key, {"code": self.valid_code, "purpose": purpose}, timeout=300)
 
         data = {"email": self.email, "code": self.valid_code, "purpose": purpose}
@@ -83,7 +83,7 @@ class EmailVerificationAPITests(IsolatedRedisTestClient):
     def test_verify_email_find_password_success(self) -> None:
         """[성공] 비밀번호 찾기 용도"""
         purpose = "find_password"
-        cache_key = f"email_code_{self.email}_{purpose}"
+        cache_key = f"email_code_{self.email}"
         cache.set(cache_key, {"code": self.valid_code, "purpose": purpose}, timeout=300)
 
         data = {"email": self.email, "code": self.valid_code, "purpose": purpose}
@@ -95,7 +95,7 @@ class EmailVerificationAPITests(IsolatedRedisTestClient):
     def test_verify_email_recovery_success(self) -> None:
         """[성공] 계정 복구 용도"""
         purpose = "recovery"
-        cache_key = f"email_code_{self.email}_{purpose}"
+        cache_key = f"email_code_{self.email}"
         cache.set(cache_key, {"code": self.valid_code, "purpose": purpose}, timeout=300)
 
         data = {"email": self.email, "code": self.valid_code, "purpose": purpose}
@@ -107,7 +107,7 @@ class EmailVerificationAPITests(IsolatedRedisTestClient):
     def test_verify_email_invalid_code(self) -> None:
         """[실패] 틀린 인증 코드 입력 시 실패 테스트"""
         purpose = "signup"
-        cache_key = f"email_code_{self.email}_{purpose}"
+        cache_key = f"email_code_{self.email}"
         cache.set(cache_key, {"code": self.valid_code, "purpose": purpose}, timeout=300)
 
         data = {"email": self.email, "code": "WRONG1", "purpose": purpose}


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약:  sms 인증 및 이메일 인증 캐쉬 키 변경

## 📄 상세 내용
- [ ] 이메일 인증  및  sms 인증 캐쉬 키에서 purpose 삭제
- [ ] 

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
