### PR TITLE
fix: 회원 탈퇴 응답 및 스웨거 문서 보완

### DIFF
--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -2,15 +2,41 @@ from __future__ import annotations
 
 from typing import Any
 
+from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.users.models import Withdrawal
 from apps.users.services.withdrawal_service import get_recovery_token_cache
 from apps.users.utils.withdrawal_exceptions import InvalidRecoveryTokenError
 
+WITHDRAWAL_REASON_VALUES = [
+    "GRADUATION",
+    "TRANSFER",
+    "NO_LONGER_NEEDED",
+    "LACK_OF_INTEREST",
+    "TOO_DIFFICULT",
+    "FOUND_BETTER_SERVICE",
+    "PRIVACY_CONCERNS",
+    "POOR_SERVICE_QUALITY",
+    "TECHNICAL_ISSUES",
+    "LACK_OF_CONTENT",
+    "OTHER",
+]
+
+
+@extend_schema_field(
+    {
+        "type": "string",
+        "enum": WITHDRAWAL_REASON_VALUES,
+        "description": "탈퇴 사유",
+    }
+)
+class WithdrawalReasonField(serializers.ChoiceField):
+    pass
+
 
 class WithdrawalSerializer(serializers.Serializer[Withdrawal]):
-    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)
+    reason = WithdrawalReasonField(choices=Withdrawal.Reason.choices)
     reason_detail = serializers.CharField(required=False, default="", allow_blank=True)
 
 

--- a/apps/users/serializers/withdrawal_serializer.py
+++ b/apps/users/serializers/withdrawal_serializer.py
@@ -2,41 +2,15 @@ from __future__ import annotations
 
 from typing import Any
 
-from drf_spectacular.utils import extend_schema_field
 from rest_framework import serializers
 
 from apps.users.models import Withdrawal
 from apps.users.services.withdrawal_service import get_recovery_token_cache
 from apps.users.utils.withdrawal_exceptions import InvalidRecoveryTokenError
 
-WITHDRAWAL_REASON_VALUES = [
-    "GRADUATION",
-    "TRANSFER",
-    "NO_LONGER_NEEDED",
-    "LACK_OF_INTEREST",
-    "TOO_DIFFICULT",
-    "FOUND_BETTER_SERVICE",
-    "PRIVACY_CONCERNS",
-    "POOR_SERVICE_QUALITY",
-    "TECHNICAL_ISSUES",
-    "LACK_OF_CONTENT",
-    "OTHER",
-]
-
-
-@extend_schema_field(
-    {
-        "type": "string",
-        "enum": WITHDRAWAL_REASON_VALUES,
-        "description": "탈퇴 사유",
-    }
-)
-class WithdrawalReasonField(serializers.ChoiceField):
-    pass
-
 
 class WithdrawalSerializer(serializers.Serializer[Withdrawal]):
-    reason = WithdrawalReasonField(choices=Withdrawal.Reason.choices)
+    reason = serializers.ChoiceField(choices=Withdrawal.Reason.choices)
     reason_detail = serializers.CharField(required=False, default="", allow_blank=True)
 
 

--- a/apps/users/utils/withdrawal_exceptions.py
+++ b/apps/users/utils/withdrawal_exceptions.py
@@ -37,7 +37,7 @@ class WithdrawalNotFoundError(WithdrawalError):
 
 class WithdrawalRecordNotFoundError(WithdrawalNotFoundError):
     def __init__(self) -> None:
-        super().__init__("탈퇴 신청 내역이 없습니다.")
+        super().__init__("회원탈퇴 정보를 찾을 수 없습니다.")
 
 
 class DeletedUserError(WithdrawalNotFoundError):


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #이슈번호
- 작업 요약: 회원 탈퇴 사유 Swagger 문서와 회원탈퇴 404 응답 메시지를 API 명세서에 맞게 보완했습니다.

## 📄 상세 내용
- [x] 탈퇴 사유 `reason` 필드가 Swagger에서 enum으로 표시되도록 수정했습니다.
- [x] 회원탈퇴 정보가 없을 때의 404 메시지를 명세서와 동일하게 수정했습니다.
- [x] 기존 회원 탈퇴/복구 로직에 영향을 주지 않는 범위에서 응답 문구와 문서화만 보완했습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- API 명세서 38~40번 구현 전 공용 응답/문서화 보완 PR입니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
