### PR TITLE
✨ feat:사용자 비밀번호 분실 시 재설정 기능 구현

### DIFF
--- a/apps/users/serializers/find_password_serializer.py
+++ b/apps/users/serializers/find_password_serializer.py
@@ -1,0 +1,22 @@
+import re
+from typing import Any
+
+from rest_framework import serializers
+
+
+class FindPasswordSerializer(serializers.Serializer[Any]):
+    email_token = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})
+    new_password = serializers.CharField(
+        write_only=True, required=True, error_messages={"required": "이 필드는 필수 항목입니다."}
+    )
+
+    def validate_new_password(self, value: str) -> str:
+        if not re.match(r"^\S{6,15}$", value):
+            raise serializers.ValidationError("비밀번호는 6~15자여야 합니다.")
+        if not re.search(r"[a-zA-Z]", value):
+            raise serializers.ValidationError("비밀번호는 영문을 포함해야 합니다.")
+        if not re.search(r"[0-9]", value):
+            raise serializers.ValidationError("비밀번호는 숫자를 포함해야 합니다.")
+        if not re.search(r"[!@#$%^&*]", value):
+            raise serializers.ValidationError("비밀번호는 특수문자를 포함해야 합니다.")
+        return value

--- a/apps/users/services/find_password_service.py
+++ b/apps/users/services/find_password_service.py
@@ -42,7 +42,7 @@ def find_password_service(validated_data: dict[str, Any]) -> None:
             user.set_password(new_password)
             user.save()
 
-            cache.delete(email_key)
+        cache.delete(email_key)
 
     # 동록된 이메일이 아닐경우
     except User.DoesNotExist:

--- a/apps/users/services/find_password_service.py
+++ b/apps/users/services/find_password_service.py
@@ -1,0 +1,49 @@
+from typing import Any
+
+from django.core.cache import cache
+from django.db import transaction
+from rest_framework.exceptions import ValidationError
+
+from apps.users.models import User
+from apps.users.utils.purpose_enum import AuthPurpose
+
+FIND_PASSWORD = AuthPurpose.FIND_PASSWORD.value
+
+
+def find_password_service(validated_data: dict[str, Any]) -> None:
+    """
+    이메일 인증 토큰을 받아 redis cache에
+    저장된 email,purpose꺼내서 유저 정보 확인후
+    새 비밀번호 업데이트
+    """
+
+    email_token = validated_data["email_token"]
+    new_password = validated_data["new_password"]
+
+    email_key = f"email_verify_token_{email_token}"
+    # 캐쉬에 저장된 용도, 이메일
+    email_data = cache.get(email_key)
+
+    # 토큰 유효한지 확인
+    if not email_data:
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+
+    if FIND_PASSWORD != email_data.get("purpose"):
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+    email = email_data.get("email")
+
+    # 비밀번호 재설정
+    try:
+        with transaction.atomic():
+            # 동시성 제어
+            user = User.objects.select_for_update().get(email=email)
+            if user.check_password(new_password):
+                raise ValidationError("기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.")
+            user.set_password(new_password)
+            user.save()
+
+            cache.delete(email_key)
+
+    # 동록된 이메일이 아닐경우
+    except User.DoesNotExist:
+        raise ValidationError("해당 이메일을 가진 사용자를 찾을 수 없습니다.")

--- a/apps/users/tests/test_find_password.py
+++ b/apps/users/tests/test_find_password.py
@@ -1,0 +1,99 @@
+import uuid
+
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+
+from apps.core.utils.isolated_cache_testcase import IsolatedRedisTestClient
+from apps.users.models import User
+from apps.users.utils.purpose_enum import AuthPurpose
+
+
+class PasswordResetAPITestCase(IsolatedRedisTestClient):
+    # 테스트에 사용할 유저 정보
+    user: User
+    user_password: str = "oldassword12!@"
+    new_password: str = "newpassword12!@"
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """테스트 전체에서 공통으로 사용할 유저 생성"""
+        cls.user = User.objects.create_user(
+            email="test@coding.com",
+            password=cls.user_password,
+            name="재설정테스터",
+            nickname="tester",
+            phone_number="010-9999-8888",
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 테스트에 사용할 API URL 및 토큰 설정
+        self.url: str = reverse("users:find_password")
+        self.email_token: str = f"token_{uuid.uuid4().hex}"
+        self.cache_key: str = f"email_verify_token_{self.email_token}"
+
+        # 기본 유효 페이로드
+        self.valid_payload = {
+            "email_token": self.email_token,
+            "new_password": self.new_password,
+        }
+
+    def set_cache_data(self, purpose: str = AuthPurpose.FIND_PASSWORD.value) -> None:
+        """Redis 캐시에 인증 데이터를 주입하는 헬퍼 메서드"""
+        cache.set(self.cache_key, {"email": self.user.email, "purpose": purpose}, timeout=300)
+
+    def test_password_reset_success(self) -> None:
+        """정상적인 토큰으로 비밀번호 재설정 성공 (200) 테스트"""
+        self.set_cache_data()
+
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        # 상태 코드 및 메시지 확인
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "비밀번호 변경 성공.")
+
+        # 실제 DB 반영 여부 확인
+        self.user.refresh_from_db()
+        self.assertTrue(self.user.check_password(self.new_password))
+
+        # 사용된 Redis 토큰 삭제 확인
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_password_reset_with_invalid_token_returns_400(self) -> None:
+        """존재하지 않거나 만료된 토큰 사용 시 400 반환 테스트"""
+        # 캐시 설정 없이 요청
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_password_reset_with_wrong_purpose_returns_400(self) -> None:
+        """비밀번호 재설정용이 아닌 다른 용도의 토큰(예: 회원가입용) 사용 시 400 반환"""
+        # SIGNUP 용도
+        self.set_cache_data(purpose=AuthPurpose.SIGNUP.value)
+
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_password_reset_missing_fields_returns_400(self) -> None:
+        """필수 필드 누락 시 400 반환 테스트"""
+        data = {"email_token": self.email_token}  # 비밀번호 필드 누락
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_password_reset_same_as_old_returns_400(self) -> None:
+        """기존 비밀번호와 동일한 비밀번호로 재설정 시도 시 400 반환"""
+        self.set_cache_data()
+
+        payload = {"email_token": self.email_token, "new_password": self.user_password}  # 기존과 동일한 값
+
+        response = self.client.post(self.url, payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "기존 비밀번호와 동일한 비밀번호로 변경할 수 없습니다.")

--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -13,4 +13,5 @@ urlpatterns = [
     path("", include("apps.users.urls.auth_sms_url")),
     path("", include("apps.users.urls.user_signup_url")),
     path("", include("apps.users.urls.user_login_url")),
+    path("", include("apps.users.urls.find_password_url")),
 ]

--- a/apps/users/urls/find_password_url.py
+++ b/apps/users/urls/find_password_url.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.users.views.find_password_view import FindPasswordView
+
+urlpatterns = [
+    path("find_password", FindPasswordView.as_view(), name="find_password"),
+]

--- a/apps/users/views/find_password_view.py
+++ b/apps/users/views/find_password_view.py
@@ -1,0 +1,37 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.find_password_serializer import FindPasswordSerializer
+from apps.users.services.find_password_service import find_password_service
+
+
+class FindPasswordView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        tags=["accounts"],
+        summary="이메일 로그인 API",
+        description="이메일과 비밀번호로 로그인합니다. Access 토큰은 바디로, Refresh 토큰은 쿠키로 반환됩니다.",
+        request=FindPasswordSerializer,
+        responses={
+            200: OpenApiResponse(description="로그인 성공"),
+            400: OpenApiResponse(description="유효성 검사 실패"),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = FindPasswordSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            find_password_service(serializer.validated_data)
+
+            return Response({"detail": "비밀번호 변경 성공."}, status=status.HTTP_200_OK)
+
+        except ValidationError as e:
+            return Response({"error_detail": e.detail}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/users/views/find_password_view.py
+++ b/apps/users/views/find_password_view.py
@@ -15,11 +15,11 @@ class FindPasswordView(APIView):
 
     @extend_schema(
         tags=["accounts"],
-        summary="이메일 로그인 API",
-        description="이메일과 비밀번호로 로그인합니다. Access 토큰은 바디로, Refresh 토큰은 쿠키로 반환됩니다.",
+        summary="비밀번호 분실시 재설정 api",
+        description="이메일 인증 후 발급받은 토큰을 활용하여 유저 비밀번호 재설정",
         request=FindPasswordSerializer,
         responses={
-            200: OpenApiResponse(description="로그인 성공"),
+            200: OpenApiResponse(description="비밀번호 재설정 성공"),
             400: OpenApiResponse(description="유효성 검사 실패"),
         },
     )


### PR DESCRIPTION
- 이메일 인증 성공 시 발급 받은 토큰을 사용하여 캐시에 저장된 정보로 이용자 확인
- 새로 설정하는 비밀번호와 기존 비밀번호 비교 검증

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 이메일 인증 토큰을 활용한 유저 비밀번호 재설정(Find Password) API 구현

## 📄 상세 내용
- [ ] 비밀번호 재설정 기능 구현
- [ ] Redis를 통한 이메일 토큰 유효성 및 용도 검증
- [ ] 정규식을 활용한 비밀번호 검증 및 기존 비밀번호로 변경 제한 


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
