### PR TITLE
[feature/exams_sub] 쪽지시험 응시내역 목록 조회 API

### DIFF
--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -7,6 +7,7 @@ from apps.exams.views.admin_exam_question_view import (
     AdminQuestionCreateView,
     AdminQuestionUpdateDeleteView,
 )
+from apps.exams.views.admin_exam_submission_view import AdminExamSubmissionView
 from apps.exams.views.admin_exam_view import ExamDetailView, ExamListCreateView
 
 
@@ -16,6 +17,7 @@ class ExamImageUploadView(PresignedUrlView):
 
 
 urlpatterns = [
+    path("submissions/", AdminExamSubmissionView.as_view(), name="exam-submission-list"),
     path("deployments/", AdminExamDeploymentView.as_view(), name="exam-deployment"),
     path("presigned-url/", ExamImageUploadView.as_view(), name="presigned-url"),
     path("<int:exam_id>/questions/", AdminQuestionCreateView.as_view(), name="exam-question-create"),

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+
+
+class AdminExamSubmissionListQuerySerializer(serializers.Serializer):
+    page = serializers.IntegerField(required=False)
+    page_size = serializers.IntegerField(required=False)
+    search_keyword = serializers.CharField(required=False)
+    cohort_id = serializers.IntegerField(required=False)
+    exam_id = serializers.IntegerField(required=False)
+    sort = serializers.ChoiceField(
+        choices=["created_at", "score"],
+        default="created_at",
+        required=False
+    )
+    order = serializers.ChoiceField(
+        choices=["asc", "desc"],
+        default="desc",
+        required=False
+    )
+
+
+class AdminExamSubmissionListSerializer(serializers.Serializer):
+    submission_id = serializers.IntegerField(source="id")
+    nickname = serializers.CharField(source="submitter.nickname")
+    name = serializers.CharField(source="submitter.name")
+    course_name = serializers.CharField(source="deployment.cohort.course.name")
+    cohort_number = serializers.IntegerField(source="deployment.cohort.number")
+    exam_title = serializers.CharField(source="deployment.exam.title")
+    subject_name = serializers.CharField(source="deployment.exam.subject.title")
+    score = serializers.IntegerField()
+    cheating_count = serializers.IntegerField()
+    started_at = serializers.DateTimeField()
+    finished_at = serializers.DateTimeField(source="created_at")

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from django.db.models import Q, QuerySet
+
+from apps.exams.models.exam_submission_model import ExamSubmission
+
+SORT_FIELD_MAP = {
+    "created_at": "created_at",
+    "score": "score",
+}
+
+
+def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmission]:
+    cohort_id = validated_params.get("cohort_id")
+    exam_id = validated_params.get("exam_id")
+    search_keyword = validated_params.get("search_keyword")
+    sort = validated_params.get("sort", "created_at")
+    order = validated_params.get("order", "desc")
+
+    qs = ExamSubmission.objects.select_related(
+        "submitter",
+        "deployment__cohort__course",
+        "deployment__exam__subject",
+    )
+
+    if cohort_id:
+        qs = qs.filter(deployment__cohort_id=cohort_id)
+    if exam_id:
+        qs = qs.filter(deployment__exam_id=exam_id)
+    if search_keyword:
+        qs = qs.filter(
+            Q(submitter__name__icontains=search_keyword) |
+            Q(submitter__nickname__icontains=search_keyword)
+        )
+
+    sort_field = SORT_FIELD_MAP.get(sort, "created_at")
+    qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)
+
+    return qs

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -1,0 +1,192 @@
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.courses.models import Cohort
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.posts.models.course import Course
+from apps.posts.models import Subject
+from apps.users.models import User
+
+
+class TestAdminExamSubmissionListAPI(APITestCase):
+    user: User
+    admin: User
+    course: Course
+    subject: Subject
+    cohort: Cohort
+    exam1: Exam
+    exam2: Exam
+    deployment1: ExamDeployment
+    deployment2: ExamDeployment
+    submission1: ExamSubmission
+    submission2: ExamSubmission
+    url: str
+    error_401: str
+    error_403: str
+    error_404: str
+    error_400: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
+            email="test@test.com",
+            password="test1234!",
+            name="테스터",
+            nickname="tester",
+            phone_number="010-1234-5678",
+            is_active=True,
+            role="STUDENT",
+        )
+        cls.admin = User.objects.create_superuser(
+            email="admin@test.com",
+            password="test1234!",
+            name="관리자",
+            nickname="admin",
+            phone_number="010-2222-5678",
+            is_active=True,
+            role="ADMIN",
+        )
+
+        cls.course = Course.objects.create(name="웹 개발", tag="WEB")
+        cls.subject = Subject.objects.create(
+            course=cls.course,
+            title="Python",
+            number_of_days=30,
+            number_of_hours=60,
+        )
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        cls.exam1 = Exam.objects.create(subject=cls.subject, title="시험1")
+        cls.exam2 = Exam.objects.create(subject=cls.subject, title="시험2")
+
+        cls.deployment1 = ExamDeployment.objects.create(
+            exam=cls.exam1,
+            cohort=cls.cohort,
+            access_code="access-code-1",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+        )
+        cls.deployment2 = ExamDeployment.objects.create(
+            exam=cls.exam2,
+            cohort=cls.cohort,
+            access_code="access-code-2",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+        )
+
+        cls.submission1 = ExamSubmission.objects.create(
+            submitter=cls.user,
+            deployment=cls.deployment1,
+            started_at=timezone.now(),
+            score=80,
+            correct_answer_count=8,
+        )
+        cls.submission2 = ExamSubmission.objects.create(
+            submitter=cls.admin,
+            deployment=cls.deployment2,
+            started_at=timezone.now(),
+            score=90,
+            correct_answer_count=9,
+        )
+
+        cls.url = reverse("exam-submission-list")
+        cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
+        cls.error_403 = "쪽지시험 응시 내역 조회 권한이 없습니다."
+        cls.error_404 = "조회된 응시 내역이 없습니다."
+        cls.error_400 = "유효하지 않은 조회 요청입니다."
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # 권한
+    def test_submission_list_as_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_submission_list_as_user(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("error_detail"), self.error_403)
+
+    def test_submission_list_as_anonymous(self) -> None:
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get("error_detail"), self.error_401)
+
+    # 조회 결과 없음
+    def test_submission_list_not_found(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "존재하지않는이름"})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data.get("error_detail"), self.error_404)
+
+    # 필터링
+    def test_submission_list_filter_by_cohort_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"cohort_id": self.cohort.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_submission_list_filter_by_exam_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"exam_id": self.exam1.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["exam_title"], "시험1")
+
+    # 검색
+    def test_submission_list_search_by_nickname(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "tester"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["nickname"], "tester")
+
+    def test_submission_list_search_by_name(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "테스터"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "테스터")
+
+    # 정렬
+    def test_submission_list_sort_by_score_desc(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "score", "order": "desc"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["score"], 90)
+
+    def test_submission_list_sort_by_score_asc(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "score", "order": "asc"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["score"], 80)
+
+    # 유효하지 않은 파라미터
+    def test_submission_list_invalid_sort(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "잘못된값"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("error_detail"), self.error_400)

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -1,0 +1,37 @@
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.permissions import IsRoleAdminUser
+from apps.exams.serializers.admin_exam_submission_serializer import (
+    AdminExamSubmissionListQuerySerializer,
+    AdminExamSubmissionListSerializer,
+)
+from apps.exams.services.admin_exam_submission_service import get_submission_list
+
+
+class AdminExamSubmissionView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request, message=None, code=None):
+        if request.authenticators and not request.successful_authenticator:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("쪽지시험 응시 내역 조회 권한이 없습니다.")
+
+    def get(self, request):
+        query_serializer = AdminExamSubmissionListQuerySerializer(data=request.query_params)
+        if not query_serializer.is_valid():
+            return Response({"error_detail": "유효하지 않은 조회 요청입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        submissions = get_submission_list(query_serializer.validated_data)
+
+        if not submissions.exists():
+            return Response({"error_detail": "조회된 응시 내역이 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        paginator = PageNumberPagination()
+        paginated = paginator.paginate_queryset(submissions, request)
+
+        serializer = AdminExamSubmissionListSerializer(paginated, many=True)
+        return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어드민 쪽지시험 응시내역 목록 조회 API 구현

## 📄 상세 내용
- [x] 응시내역 목록 조회 QuerySerializer 작성
- [x] 응시내역 목록 조회 ListSerializer 작성
- [x] 응시내역 목록 조회 Service 작성 (필터링, 정렬 포함)
- [x] 응시내역 목록 조회 View 작성
- [x] URL 등록 (submissions/)
- [x] 테스트 코드 작성 (11개)

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
