### PR TITLE
[Feature/exams_sub] 쪽지시험 응시내역 API 구현

### DIFF
--- a/.github/workflows/pr_review_request.yml
+++ b/.github/workflows/pr_review_request.yml
@@ -1,4 +1,4 @@
-name: Notify on PR review request
+name: Notify on PR reviews request
 
 on:
   pull_request:

--- a/apps/exams/admin_urls.py
+++ b/apps/exams/admin_urls.py
@@ -12,6 +12,10 @@ from apps.exams.views.admin_exam_question_view import (
     AdminQuestionCreateView,
     AdminQuestionUpdateDeleteView,
 )
+from apps.exams.views.admin_exam_submission_view import (
+    AdminExamSubmissionDetailView,
+    AdminExamSubmissionView,
+)
 from apps.exams.views.admin_exam_view import ExamDetailView, ExamListCreateView
 
 
@@ -22,6 +26,8 @@ class ExamImageUploadView(PresignedUrlView):
 
 
 urlpatterns = [
+    path("submissions/", AdminExamSubmissionView.as_view(), name="exam-submission-list"),
+    path("submissions/<int:submission_id>/", AdminExamSubmissionDetailView.as_view(), name="exam-submission-detail"),
     path("deployments", AdminExamDeploymentView.as_view(), name="exam-deployment"),
     path("deployments/<str:deployment_id>", AdminExamDeploymentDetailView.as_view(), name="exam-deployment-detail"),
     path(

--- a/apps/exams/exceptions/admin_exam_submission_exception.py
+++ b/apps/exams/exceptions/admin_exam_submission_exception.py
@@ -1,0 +1,13 @@
+class SubmissionNotFoundError(Exception):
+    def __init__(self, message: str = "해당 응시 내역을 찾을 수 없습니다."):
+        super().__init__(message)
+
+
+class SubmissionDeleteNotFoundError(Exception):
+    def __init__(self, message: str = "삭제할 응시 내역을 찾을 수 없습니다."):
+        super().__init__(message)
+
+
+class SubmissionConflictError(Exception):
+    def __init__(self, message: str = "응시 내역 삭제 처리 중 충돌이 발생했습니다."):
+        super().__init__(message)

--- a/apps/exams/exceptions/exam_submission_exception.py
+++ b/apps/exams/exceptions/exam_submission_exception.py
@@ -1,3 +1,13 @@
 class UserSubmissionNotFound(Exception):
     def __init__(self, message: str = "해당 시험 정보를 찾을 수 없습니다."):
         super().__init__(message)
+
+
+class DeploymentNotFound(Exception):
+    def __init__(self, message: str = "해당 시험 정보를 찾을 수 없습니다."):
+        super().__init__(message)
+
+
+class SubmissionAlreadyExists(Exception):
+    def __init__(self, message: str = "이미 제출된 시험입니다."):
+        super().__init__(message)

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -61,7 +61,7 @@ class ResultDetailSerializer(serializers.Serializer[Any]):
         return len(obj.deployment.questions_snapshot_json)
 
     def get_elapsed_time(self, obj: Any) -> int:
-        return int((obj.created_at - obj.started_at).total_seconds() // 60)
+        return int((obj.created_at - obj.started_at).total_seconds())
 
 
 class QuestionDetailSerializer(serializers.Serializer[Any]):
@@ -102,7 +102,7 @@ class AdminExamSubmissionDetailSerializer(serializers.Serializer[Any]):
                     "type": q.get("type"),
                     "question": q.get("question"),
                     "prompt": q.get("prompt"),
-                    "options": q.get("options"),
+                    "options": q.get("options_json"),
                     "point": q.get("point"),
                     "answer": q.get("answer"),
                     "submitted_answer": submitted_answer,

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -1,19 +1,25 @@
-from typing import Any
-
 from rest_framework import serializers
 
 
-class AdminExamSubmissionListQuerySerializer(serializers.Serializer[Any]):
+class AdminExamSubmissionListQuerySerializer(serializers.Serializer):
     page = serializers.IntegerField(required=False)
     page_size = serializers.IntegerField(required=False)
     search_keyword = serializers.CharField(required=False)
     cohort_id = serializers.IntegerField(required=False)
     exam_id = serializers.IntegerField(required=False)
-    sort = serializers.ChoiceField(choices=["created_at", "score"], default="created_at", required=False)
-    order = serializers.ChoiceField(choices=["asc", "desc"], default="desc", required=False)
+    sort = serializers.ChoiceField(
+        choices=["created_at", "score"],
+        default="created_at",
+        required=False
+    )
+    order = serializers.ChoiceField(
+        choices=["asc", "desc"],
+        default="desc",
+        required=False
+    )
 
 
-class AdminExamSubmissionListSerializer(serializers.Serializer[Any]):
+class AdminExamSubmissionListSerializer(serializers.Serializer):
     submission_id = serializers.IntegerField(source="id")
     nickname = serializers.CharField(source="submitter.nickname")
     name = serializers.CharField(source="submitter.name")

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -1,25 +1,19 @@
+from typing import Any
+
 from rest_framework import serializers
 
 
-class AdminExamSubmissionListQuerySerializer(serializers.Serializer):
-    page = serializers.IntegerField(required=False)
-    page_size = serializers.IntegerField(required=False)
-    search_keyword = serializers.CharField(required=False)
-    cohort_id = serializers.IntegerField(required=False)
-    exam_id = serializers.IntegerField(required=False)
-    sort = serializers.ChoiceField(
-        choices=["created_at", "score"],
-        default="created_at",
-        required=False
-    )
-    order = serializers.ChoiceField(
-        choices=["asc", "desc"],
-        default="desc",
-        required=False
-    )
+class AdminExamSubmissionListQuerySerializer(serializers.Serializer[Any]):
+    page = serializers.IntegerField(required=False, min_value=1, default=1)
+    page_size = serializers.IntegerField(required=False, min_value=1)
+    search_keyword = serializers.CharField(required=False, allow_blank=True)
+    cohort_id = serializers.IntegerField(required=False, min_value=1)
+    exam_id = serializers.IntegerField(required=False, min_value=1)
+    sort = serializers.ChoiceField(choices=["created_at", "score"], default="created_at", required=False)
+    order = serializers.ChoiceField(choices=["asc", "desc"], default="desc", required=False)
 
 
-class AdminExamSubmissionListSerializer(serializers.Serializer):
+class AdminExamSubmissionListSerializer(serializers.Serializer[Any]):
     submission_id = serializers.IntegerField(source="id")
     nickname = serializers.CharField(source="submitter.nickname")
     name = serializers.CharField(source="submitter.name")

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -1,0 +1,33 @@
+from rest_framework import serializers
+
+
+class AdminExamSubmissionListQuerySerializer(serializers.Serializer):
+    page = serializers.IntegerField(required=False)
+    page_size = serializers.IntegerField(required=False)
+    search_keyword = serializers.CharField(required=False)
+    cohort_id = serializers.IntegerField(required=False)
+    exam_id = serializers.IntegerField(required=False)
+    sort = serializers.ChoiceField(
+        choices=["created_at", "score"],
+        default="created_at",
+        required=False
+    )
+    order = serializers.ChoiceField(
+        choices=["asc", "desc"],
+        default="desc",
+        required=False
+    )
+
+
+class AdminExamSubmissionListSerializer(serializers.Serializer):
+    submission_id = serializers.IntegerField(source="id")
+    nickname = serializers.CharField(source="submitter.nickname")
+    name = serializers.CharField(source="submitter.name")
+    course_name = serializers.CharField(source="deployment.cohort.course.name")
+    cohort_number = serializers.IntegerField(source="deployment.cohort.number")
+    exam_title = serializers.CharField(source="deployment.exam.title")
+    subject_name = serializers.CharField(source="deployment.exam.subject.title")
+    score = serializers.IntegerField()
+    cheating_count = serializers.IntegerField()
+    started_at = serializers.DateTimeField()
+    finished_at = serializers.DateTimeField(source="created_at")

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -25,3 +25,85 @@ class AdminExamSubmissionListSerializer(serializers.Serializer[Any]):
     cheating_count = serializers.IntegerField()
     started_at = serializers.DateTimeField()
     finished_at = serializers.DateTimeField(source="created_at")
+
+
+class AdminExamSubmissionPathSerializer(serializers.Serializer[Any]):
+    submission_id = serializers.IntegerField(min_value=1)
+
+
+class ExamDetailSerializer(serializers.Serializer[Any]):
+    exam_title = serializers.CharField(source="exam.title")
+    subject_name = serializers.CharField(source="exam.subject.title")
+    duration_time = serializers.IntegerField()
+    open_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    close_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
+
+class StudentDetailSerializer(serializers.Serializer[Any]):
+    nickname = serializers.CharField(source="submitter.nickname")
+    name = serializers.CharField(source="submitter.name")
+    course_name = serializers.CharField(source="deployment.cohort.course.name")
+    cohort_number = serializers.IntegerField(source="deployment.cohort.number")
+
+
+class ResultDetailSerializer(serializers.Serializer[Any]):
+    score = serializers.IntegerField()
+    correct_answer_count = serializers.IntegerField()
+    cheating_count = serializers.IntegerField()
+    total_question_count = serializers.SerializerMethodField()
+    elapsed_time = serializers.SerializerMethodField()
+
+    def get_total_question_count(self, obj: Any) -> int:
+        return len(obj.deployment.questions_snapshot_json)
+
+    def get_elapsed_time(self, obj: Any) -> int:
+        return int((obj.created_at - obj.started_at).total_seconds() // 60)
+
+
+class QuestionDetailSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    number = serializers.IntegerField()
+    type = serializers.CharField()
+    question = serializers.CharField()
+    prompt = serializers.CharField(allow_null=True)
+    options = serializers.ListField(
+        child=serializers.CharField(),
+        allow_null=True,
+        allow_empty=True,
+    )
+    point = serializers.IntegerField()
+    answer = serializers.JSONField()
+    submitted_answer = serializers.JSONField(allow_null=True)
+    is_correct = serializers.BooleanField()
+    explanation = serializers.CharField()
+
+
+class AdminExamSubmissionDetailSerializer(serializers.Serializer[Any]):
+    exam = ExamDetailSerializer(source="deployment")
+    student = StudentDetailSerializer(source="*")
+    result = ResultDetailSerializer(source="*")
+    questions = serializers.SerializerMethodField()
+
+    def get_questions(self, obj: Any) -> list[dict[str, Any]]:
+        snapshot = obj.deployment.questions_snapshot_json
+        answers = obj.answer_json
+        questions = []
+        for idx, q in enumerate(snapshot, start=1):
+            q_id = str(q.get("id"))
+            answer_data = answers.get(q_id, {})
+            questions.append(
+                {
+                    "id": q.get("id"),
+                    "number": idx,
+                    "type": q.get("type"),
+                    "question": q.get("question"),
+                    "prompt": q.get("prompt"),
+                    "options": q.get("options"),
+                    "point": q.get("point"),
+                    "answer": q.get("answer"),
+                    "submitted_answer": answer_data.get("submitted_answer"),
+                    "is_correct": answer_data.get("is_correct", False),
+                    "explanation": q.get("explanation"),
+                }
+            )
+        return questions

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -1,25 +1,19 @@
+from typing import Any
+
 from rest_framework import serializers
 
 
-class AdminExamSubmissionListQuerySerializer(serializers.Serializer):
+class AdminExamSubmissionListQuerySerializer(serializers.Serializer[Any]):
     page = serializers.IntegerField(required=False)
     page_size = serializers.IntegerField(required=False)
     search_keyword = serializers.CharField(required=False)
     cohort_id = serializers.IntegerField(required=False)
     exam_id = serializers.IntegerField(required=False)
-    sort = serializers.ChoiceField(
-        choices=["created_at", "score"],
-        default="created_at",
-        required=False
-    )
-    order = serializers.ChoiceField(
-        choices=["asc", "desc"],
-        default="desc",
-        required=False
-    )
+    sort = serializers.ChoiceField(choices=["created_at", "score"], default="created_at", required=False)
+    order = serializers.ChoiceField(choices=["asc", "desc"], default="desc", required=False)
 
 
-class AdminExamSubmissionListSerializer(serializers.Serializer):
+class AdminExamSubmissionListSerializer(serializers.Serializer[Any]):
     submission_id = serializers.IntegerField(source="id")
     nickname = serializers.CharField(source="submitter.nickname")
     name = serializers.CharField(source="submitter.name")

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -4,13 +4,17 @@ from rest_framework import serializers
 
 
 class AdminExamSubmissionListQuerySerializer(serializers.Serializer[Any]):
-    page = serializers.IntegerField(required=False, min_value=1, default=1)
-    page_size = serializers.IntegerField(required=False, min_value=1)
-    search_keyword = serializers.CharField(required=False, allow_blank=True)
-    cohort_id = serializers.IntegerField(required=False, min_value=1)
-    exam_id = serializers.IntegerField(required=False, min_value=1)
-    sort = serializers.ChoiceField(choices=["created_at", "score"], default="created_at", required=False)
-    order = serializers.ChoiceField(choices=["asc", "desc"], default="desc", required=False)
+    page = serializers.IntegerField(required=False, min_value=1, default=1, help_text="페이지 번호")
+    page_size = serializers.IntegerField(required=False, min_value=1, help_text="목록 출력 개수")
+    search_keyword = serializers.CharField(required=False, help_text="닉네임 또는 이름으로 검색")
+    cohort_id = serializers.IntegerField(required=False, min_value=1, help_text="기수 ID로 필터링")
+    exam_id = serializers.IntegerField(required=False, min_value=1, help_text="시험 ID로 필터링")
+    sort = serializers.ChoiceField(
+        choices=["created_at", "score"], default="created_at", required=False, help_text="정렬 기준 (created_at, score)"
+    )
+    order = serializers.ChoiceField(
+        choices=["asc", "desc"], default="desc", required=False, help_text="정렬 순서 (asc, desc)"
+    )
 
 
 class AdminExamSubmissionListSerializer(serializers.Serializer[Any]):

--- a/apps/exams/serializers/admin_exam_submission_serializer.py
+++ b/apps/exams/serializers/admin_exam_submission_serializer.py
@@ -90,7 +90,7 @@ class AdminExamSubmissionDetailSerializer(serializers.Serializer[Any]):
         questions = []
         for idx, q in enumerate(snapshot, start=1):
             q_id = str(q.get("id"))
-            answer_data = answers.get(q_id, {})
+            submitted_answer = answers.get(q_id)
             questions.append(
                 {
                     "id": q.get("id"),
@@ -101,8 +101,8 @@ class AdminExamSubmissionDetailSerializer(serializers.Serializer[Any]):
                     "options": q.get("options"),
                     "point": q.get("point"),
                     "answer": q.get("answer"),
-                    "submitted_answer": answer_data.get("submitted_answer"),
-                    "is_correct": answer_data.get("is_correct", False),
+                    "submitted_answer": submitted_answer,
+                    "is_correct": submitted_answer == q.get("answer"),
                     "explanation": q.get("explanation"),
                 }
             )

--- a/apps/exams/serializers/user_exam_submission_serializer.py
+++ b/apps/exams/serializers/user_exam_submission_serializer.py
@@ -107,3 +107,25 @@ class UserExamSubmissionExtendSchemaSerializer(serializers.Serializer[Any]):
     elapsed_time = serializers.IntegerField()
     started_at = serializers.DateTimeField()
     submitted_at = serializers.DateTimeField()
+
+
+class AnswerItemSerializer(serializers.Serializer[Any]):
+    question_id = serializers.IntegerField(min_value=1)
+    type = serializers.ChoiceField(
+        choices=["single_choice", "multiple_choice", "short_answer", "fill_blank", "ox", "ordering"]
+    )
+    submitted_answer = serializers.JSONField(required=False)
+
+
+class UserExamSubmissionCreateSerializer(serializers.Serializer[Any]):
+    deployment_id = serializers.IntegerField(min_value=1)
+    started_at = serializers.DateTimeField()
+    cheating_count = serializers.IntegerField(min_value=0, max_value=3)
+    answers = AnswerItemSerializer(many=True)
+
+
+class UserExamSubmissionCreateResponseSerializer(serializers.Serializer[Any]):
+    submission_id = serializers.IntegerField()
+    score = serializers.IntegerField()
+    correct_answer_count = serializers.IntegerField()
+    redirect_url = serializers.CharField()

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -28,9 +28,7 @@ def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmis
     if exam_id:
         qs = qs.filter(deployment__exam_id=exam_id)
     if search_keyword:
-        qs = qs.filter(
-            Q(submitter__name__icontains=search_keyword) | Q(submitter__nickname__icontains=search_keyword)
-        )
+        qs = qs.filter(Q(submitter__name__icontains=search_keyword) | Q(submitter__nickname__icontains=search_keyword))
 
     sort_field = SORT_FIELD_MAP.get(sort, "created_at")
     qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -28,10 +28,7 @@ def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmis
     if exam_id:
         qs = qs.filter(deployment__exam_id=exam_id)
     if search_keyword:
-        qs = qs.filter(
-            Q(submitter__name__icontains=search_keyword) |
-            Q(submitter__nickname__icontains=search_keyword)
-        )
+        qs = qs.filter(Q(submitter__name__icontains=search_keyword) | Q(submitter__nickname__icontains=search_keyword))
 
     sort_field = SORT_FIELD_MAP.get(sort, "created_at")
     qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -28,7 +28,10 @@ def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmis
     if exam_id:
         qs = qs.filter(deployment__exam_id=exam_id)
     if search_keyword:
-        qs = qs.filter(Q(submitter__name__icontains=search_keyword) | Q(submitter__nickname__icontains=search_keyword))
+        qs = qs.filter(
+            Q(submitter__name__icontains=search_keyword) |
+            Q(submitter__nickname__icontains=search_keyword)
+        )
 
     sort_field = SORT_FIELD_MAP.get(sort, "created_at")
     qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -2,6 +2,11 @@ from typing import Any
 
 from django.db.models import Q, QuerySet
 
+from apps.exams.exceptions.admin_exam_submission_exception import (
+    SubmissionConflictError,
+    SubmissionDeleteNotFoundError,
+    SubmissionNotFoundError,
+)
 from apps.exams.models.exam_submission_model import ExamSubmission
 
 SORT_FIELD_MAP = {
@@ -34,3 +39,25 @@ def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmis
     qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)
 
     return qs
+
+
+def get_submission_detail(submission_id: int) -> ExamSubmission:
+    try:
+        return ExamSubmission.objects.select_related(
+            "submitter",
+            "deployment__cohort__course",
+            "deployment__exam__subject",
+        ).get(id=submission_id)
+    except ExamSubmission.DoesNotExist:
+        raise SubmissionNotFoundError()
+
+
+def delete_submission(submission_id: int) -> None:
+    try:
+        submission = ExamSubmission.objects.get(id=submission_id)
+    except ExamSubmission.DoesNotExist:
+        raise SubmissionDeleteNotFoundError()
+    try:
+        submission.delete()
+    except Exception:
+        raise SubmissionConflictError()

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -1,0 +1,39 @@
+from typing import Any
+
+from django.db.models import Q, QuerySet
+
+from apps.exams.models.exam_submission_model import ExamSubmission
+
+SORT_FIELD_MAP = {
+    "created_at": "created_at",
+    "score": "score",
+}
+
+
+def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmission]:
+    cohort_id = validated_params.get("cohort_id")
+    exam_id = validated_params.get("exam_id")
+    search_keyword = validated_params.get("search_keyword")
+    sort = validated_params.get("sort", "created_at")
+    order = validated_params.get("order", "desc")
+
+    qs = ExamSubmission.objects.select_related(
+        "submitter",
+        "deployment__cohort__course",
+        "deployment__exam__subject",
+    )
+
+    if cohort_id:
+        qs = qs.filter(deployment__cohort_id=cohort_id)
+    if exam_id:
+        qs = qs.filter(deployment__exam_id=exam_id)
+    if search_keyword:
+        qs = qs.filter(
+            Q(submitter__name__icontains=search_keyword) |
+            Q(submitter__nickname__icontains=search_keyword)
+        )
+
+    sort_field = SORT_FIELD_MAP.get(sort, "created_at")
+    qs = qs.order_by(f"-{sort_field}" if order == "desc" else sort_field)
+
+    return qs

--- a/apps/exams/services/admin_exam_submission_service.py
+++ b/apps/exams/services/admin_exam_submission_service.py
@@ -29,8 +29,7 @@ def get_submission_list(validated_params: dict[str, Any]) -> QuerySet[ExamSubmis
         qs = qs.filter(deployment__exam_id=exam_id)
     if search_keyword:
         qs = qs.filter(
-            Q(submitter__name__icontains=search_keyword) |
-            Q(submitter__nickname__icontains=search_keyword)
+            Q(submitter__name__icontains=search_keyword) | Q(submitter__nickname__icontains=search_keyword)
         )
 
     sort_field = SORT_FIELD_MAP.get(sort, "created_at")

--- a/apps/exams/services/user_exam_submission_service.py
+++ b/apps/exams/services/user_exam_submission_service.py
@@ -1,7 +1,11 @@
-from django.db.models import QuerySet
+from typing import Any
 
-from apps.exams.exceptions.exam_submission_exception import UserSubmissionNotFound
-from apps.exams.models import ExamSubmission
+from apps.exams.exceptions.exam_submission_exception import (
+    DeploymentNotFound,
+    SubmissionAlreadyExists,
+    UserSubmissionNotFound,
+)
+from apps.exams.models import ExamDeployment, ExamSubmission
 
 
 def get_submission_detail(submitter: int, submission_id: int) -> ExamSubmission:
@@ -11,3 +15,44 @@ def get_submission_detail(submitter: int, submission_id: int) -> ExamSubmission:
         )
     except ExamSubmission.DoesNotExist:
         raise UserSubmissionNotFound()
+
+
+def create_submission(submitter_id: int, validated_data: dict[str, Any]) -> ExamSubmission:
+    deployment_id = validated_data["deployment_id"]
+    started_at = validated_data["started_at"]
+    cheating_count = validated_data["cheating_count"]
+    answers = validated_data["answers"]
+
+    try:
+        deployment = ExamDeployment.objects.get(id=deployment_id)
+    except ExamDeployment.DoesNotExist:
+        raise DeploymentNotFound()
+
+    if ExamSubmission.objects.filter(submitter_id=submitter_id, deployment=deployment).exists():
+        raise SubmissionAlreadyExists()
+
+    snapshot_map = {str(q["id"]): q for q in deployment.questions_snapshot_json}
+    answer_json: dict[str, list[str]] = {}
+    score = 0
+    correct_count = 0
+
+    for answer in answers:
+        q_id = str(answer["question_id"])
+        submitted = answer["submitted_answer"]
+        submitted_list = [submitted] if isinstance(submitted, str) else list(submitted)
+        answer_json[q_id] = submitted_list
+
+        snap_q = snapshot_map.get(q_id)
+        if snap_q and submitted_list == snap_q.get("answer", []):
+            score += snap_q.get("point", 0)
+            correct_count += 1
+
+    return ExamSubmission.objects.create(
+        submitter_id=submitter_id,
+        deployment=deployment,
+        started_at=started_at,
+        cheating_count=cheating_count,
+        answer_json=answer_json,
+        score=score,
+        correct_answer_count=correct_count,
+    )

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -188,3 +188,275 @@ class TestAdminExamSubmissionListAPI(APITestCase):
 
         self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
         self.assertEqual(response.data.get("error_detail"), self.error_400)
+
+
+class TestAdminExamSubmissionDetailAPI(APITestCase):
+    user: User
+    admin: User
+    course: Course
+    subject: Subject
+    cohort: Cohort
+    exam: Exam
+    deployment: ExamDeployment
+    submission: ExamSubmission
+    url: str
+    error_401: str
+    error_403: str
+    error_404: str
+    error_400: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
+            email="detail_test@test.com",
+            password="test1234!",
+            name="테스터",
+            nickname="tester2",
+            phone_number="010-3333-5678",
+            is_active=True,
+            role="STUDENT",
+        )
+        cls.admin = User.objects.create_superuser(
+            email="detail_admin@test.com",
+            password="test1234!",
+            name="관리자",
+            nickname="admin2",
+            phone_number="010-4444-5678",
+            is_active=True,
+            role="ADMIN",
+        )
+
+        cls.course = Course.objects.create(name="백엔드 개발", tag="WEB")
+        cls.subject = Subject.objects.create(
+            course=cls.course,
+            title="Python",
+            number_of_days=30,
+            number_of_hours=60,
+        )
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        cls.exam = Exam.objects.create(subject=cls.subject, title="Python 기본 문법 테스트")
+
+        cls.deployment = ExamDeployment.objects.create(
+            exam=cls.exam,
+            cohort=cls.cohort,
+            access_code="access-code-detail",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+            questions_snapshot_json=[
+                {
+                    "id": 1,
+                    "type": "multiple_choice",
+                    "question": "Python의 특징은?",
+                    "prompt": None,
+                    "options": ["인터프리터 언어", "정적 타입", "메모리 수동 관리"],
+                    "point": 10,
+                    "answer": "인터프리터 언어",
+                    "explanation": "Python은 인터프리터 언어입니다.",
+                }
+            ],
+        )
+
+        cls.submission = ExamSubmission.objects.create(
+            submitter=cls.user,
+            deployment=cls.deployment,
+            started_at=timezone.now(),
+            score=80,
+            correct_answer_count=1,
+            cheating_count=0,
+            answer_json={
+                "1": {
+                    "submitted_answer": "인터프리터 언어",
+                    "is_correct": True,
+                }
+            },
+        )
+
+        cls.url = reverse("exam-submission-detail", kwargs={"submission_id": cls.submission.id})
+        cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
+        cls.error_403 = "쪽지시험 응시 상세 조회 권한이 없습니다."
+        cls.error_404 = "해당 응시 내역을 찾을 수 없습니다."
+        cls.error_400 = "유효하지 않은 상세 조회 요청입니다."
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # 권한
+    def test_submission_detail_as_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    def test_submission_detail_as_user(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("error_detail"), self.error_403)
+
+    def test_submission_detail_as_anonymous(self) -> None:
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get("error_detail"), self.error_401)
+
+    # 조회 성공
+    def test_submission_detail_success(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["exam"]["exam_title"], "Python 기본 문법 테스트")
+        self.assertEqual(response.data["student"]["nickname"], "tester2")
+        self.assertEqual(response.data["result"]["score"], 80)
+        self.assertEqual(len(response.data["questions"]), 1)
+
+    # 404
+    def test_submission_detail_not_found(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        url = reverse("exam-submission-detail", kwargs={"submission_id": 99999})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data.get("error_detail"), self.error_404)
+
+    # 유효하지 않은 파라미터
+    def test_submission_detail_invalid_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        url = reverse("exam-submission-detail", kwargs={"submission_id": 0})
+        response = self.client.get(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("error_detail"), self.error_400)
+
+
+class TestAdminExamSubmissionDeleteAPI(APITestCase):
+    user: User
+    admin: User
+    course: Course
+    subject: Subject
+    cohort: Cohort
+    exam: Exam
+    deployment: ExamDeployment
+    submission: ExamSubmission
+    url: str
+    error_401: str
+    error_403: str
+    error_404: str
+    error_400: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
+            email="delete_test@test.com",
+            password="test1234!",
+            name="테스터",
+            nickname="tester3",
+            phone_number="010-5555-5678",
+            is_active=True,
+            role="STUDENT",
+        )
+        cls.admin = User.objects.create_superuser(
+            email="delete_admin@test.com",
+            password="test1234!",
+            name="관리자",
+            nickname="admin3",
+            phone_number="010-6666-5678",
+            is_active=True,
+            role="ADMIN",
+        )
+
+        cls.course = Course.objects.create(name="풀스택 개발", tag="WEB")
+        cls.subject = Subject.objects.create(
+            course=cls.course,
+            title="Django",
+            number_of_days=30,
+            number_of_hours=60,
+        )
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        cls.exam = Exam.objects.create(subject=cls.subject, title="Django 테스트")
+
+        cls.deployment = ExamDeployment.objects.create(
+            exam=cls.exam,
+            cohort=cls.cohort,
+            access_code="access-code-delete",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+        )
+
+        cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
+        cls.error_403 = "쪽지시험 응시 내역 삭제 권한이 없습니다."
+        cls.error_404 = "삭제할 응시 내역을 찾을 수 없습니다."
+        cls.error_400 = "유효하지 않은 응시 내역 삭제 요청입니다."
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.submission = ExamSubmission.objects.create(
+            submitter=self.user,
+            deployment=self.deployment,
+            started_at=timezone.now(),
+            score=70,
+            correct_answer_count=7,
+        )
+        self.url = reverse("exam-submission-detail", kwargs={"submission_id": self.submission.id})
+
+    # 권한
+    def test_submission_delete_as_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data.get("submission_id"), self.submission.id)
+
+    def test_submission_delete_as_user(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("error_detail"), self.error_403)
+
+    def test_submission_delete_as_anonymous(self) -> None:
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get("error_detail"), self.error_401)
+
+    # 삭제 성공
+    def test_submission_delete_success(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.delete(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(ExamSubmission.objects.filter(id=self.submission.id).exists())
+
+    # 404
+    def test_submission_delete_not_found(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        url = reverse("exam-submission-detail", kwargs={"submission_id": 99999})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data.get("error_detail"), self.error_404)
+
+    # 유효하지 않은 파라미터
+    def test_submission_delete_invalid_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        url = reverse("exam-submission-detail", kwargs={"submission_id": 0})
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("error_detail"), self.error_400)

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -25,7 +25,6 @@ class TestAdminExamSubmissionListAPI(APITestCase):
     url: str
     error_401: str
     error_403: str
-    error_404: str
     error_400: str
 
     @classmethod
@@ -100,7 +99,6 @@ class TestAdminExamSubmissionListAPI(APITestCase):
         cls.url = reverse("exam-submission-list")
         cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
         cls.error_403 = "쪽지시험 응시 내역 조회 권한이 없습니다."
-        cls.error_404 = "조회된 응시 내역이 없습니다."
         cls.error_400 = "유효하지 않은 조회 요청입니다."
 
     def setUp(self) -> None:
@@ -132,8 +130,8 @@ class TestAdminExamSubmissionListAPI(APITestCase):
         self.client.force_authenticate(user=self.admin)
         response = self.client.get(self.url, {"search_keyword": "존재하지않는이름"})
 
-        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
-        self.assertEqual(response.data.get("error_detail"), self.error_404)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
 
     # 필터링
     def test_submission_list_filter_by_cohort_id(self) -> None:

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -5,8 +5,8 @@ from rest_framework.test import APIClient, APITestCase
 
 from apps.courses.models import Cohort
 from apps.exams.models import Exam, ExamDeployment, ExamSubmission
-from apps.posts.models.course import Course
 from apps.posts.models import Subject
+from apps.posts.models.course import Course
 from apps.users.models import User
 
 

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -6,7 +6,7 @@ from rest_framework.test import APIClient, APITestCase
 from apps.courses.models import Cohort
 from apps.exams.models import Exam, ExamDeployment, ExamSubmission
 from apps.posts.models import Subject
-from apps.posts.models.course import Course
+from apps.courses.models.course import Course
 from apps.users.models import User
 
 

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -4,9 +4,9 @@ from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
 from apps.courses.models import Cohort
+from apps.courses.models.course import Course
 from apps.exams.models import Exam, ExamDeployment, ExamSubmission
 from apps.posts.models import Subject
-from apps.courses.models.course import Course
 from apps.users.models import User
 
 

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -1,0 +1,192 @@
+from django.urls import reverse
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.courses.models import Cohort
+from apps.exams.models import Exam, ExamDeployment, ExamSubmission
+from apps.posts.models.course import Course
+from apps.posts.models import Subject
+from apps.users.models import User
+
+
+class TestAdminExamSubmissionListAPI(APITestCase):
+    user: User
+    admin: User
+    course: Course
+    subject: Subject
+    cohort: Cohort
+    exam1: Exam
+    exam2: Exam
+    deployment1: ExamDeployment
+    deployment2: ExamDeployment
+    submission1: ExamSubmission
+    submission2: ExamSubmission
+    url: str
+    error_401: str
+    error_403: str
+    error_404: str
+    error_400: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.user = User.objects.create_user(
+            email="test@test.com",
+            password="test1234!",
+            name="테스터",
+            nickname="tester",
+            phone_number="010-1234-5678",
+            is_active=True,
+            role="STUDENT",
+        )
+        cls.admin = User.objects.create_superuser(
+            email="admin@test.com",
+            password="test1234!",
+            name="관리자",
+            nickname="admin",
+            phone_number="010-2222-5678",
+            is_active=True,
+            role="ADMIN",
+        )
+
+        cls.course = Course.objects.create(name="웹 개발", tag="WEB")
+        cls.subject = Subject.objects.create(
+            course=cls.course,
+            title="Python",
+            number_of_days=30,
+            number_of_hours=60,
+        )
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+
+        cls.exam1 = Exam.objects.create(subject=cls.subject, title="시험1")
+        cls.exam2 = Exam.objects.create(subject=cls.subject, title="시험2")
+
+        cls.deployment1 = ExamDeployment.objects.create(
+            exam=cls.exam1,
+            cohort=cls.cohort,
+            access_code="access-code-1",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+        )
+        cls.deployment2 = ExamDeployment.objects.create(
+            exam=cls.exam2,
+            cohort=cls.cohort,
+            access_code="access-code-2",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+        )
+
+        cls.submission1 = ExamSubmission.objects.create(
+            submitter=cls.user,
+            deployment=cls.deployment1,
+            started_at=timezone.now(),
+            score=80,
+            correct_answer_count=8,
+        )
+        cls.submission2 = ExamSubmission.objects.create(
+            submitter=cls.admin,
+            deployment=cls.deployment2,
+            started_at=timezone.now(),
+            score=90,
+            correct_answer_count=9,
+        )
+
+        cls.url = reverse("exam-submission-list")
+        cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
+        cls.error_403 = "쪽지시험 응시 내역 조회 권한이 없습니다."
+        cls.error_404 = "조회된 응시 내역이 없습니다."
+        cls.error_400 = "유효하지 않은 조회 요청입니다."
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # 권한
+    def test_submission_list_as_admin(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_submission_list_as_user(self) -> None:
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("error_detail"), self.error_403)
+
+    def test_submission_list_as_anonymous(self) -> None:
+        response = self.client.get(self.url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get("error_detail"), self.error_401)
+
+    # 조회 결과 없음
+    def test_submission_list_not_found(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "존재하지않는이름"})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data.get("error_detail"), self.error_404)
+
+    # 필터링
+    def test_submission_list_filter_by_cohort_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"cohort_id": self.cohort.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 2)
+
+    def test_submission_list_filter_by_exam_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"exam_id": self.exam1.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["exam_title"], "시험1")
+
+    # 검색
+    def test_submission_list_search_by_nickname(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "tester"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["nickname"], "tester")
+
+    def test_submission_list_search_by_name(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search_keyword": "테스터"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 1)
+        self.assertEqual(response.data["results"][0]["name"], "테스터")
+
+    # 정렬
+    def test_submission_list_sort_by_score_desc(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "score", "order": "desc"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["score"], 90)
+
+    def test_submission_list_sort_by_score_asc(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "score", "order": "asc"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["results"][0]["score"], 80)
+
+    # 유효하지 않은 파라미터
+    def test_submission_list_invalid_sort(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"sort": "잘못된값"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("error_detail"), self.error_400)

--- a/apps/exams/tests/test_admin_exam_submission.py
+++ b/apps/exams/tests/test_admin_exam_submission.py
@@ -271,10 +271,7 @@ class TestAdminExamSubmissionDetailAPI(APITestCase):
             correct_answer_count=1,
             cheating_count=0,
             answer_json={
-                "1": {
-                    "submitted_answer": "인터프리터 언어",
-                    "is_correct": True,
-                }
+                "1": ["인터프리터 언어"],
             },
         )
 

--- a/apps/exams/tests/test_user_exam_submission.py
+++ b/apps/exams/tests/test_user_exam_submission.py
@@ -1,3 +1,5 @@
+from typing import Any
+
 from django.urls import reverse
 from django.utils import timezone
 from rest_framework import status
@@ -231,3 +233,170 @@ class TestUserExamSubmissionGet(BaseTestCase):
 
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
         self.assertEqual(response.data["error_detail"], "자격 인증 데이터가 제공되지 않았습니다.")
+
+
+class TestUserExamSubmissionCreate(APITestCase):
+    student: User
+    normal_user: User
+    course: Course
+    subject: Subject
+    cohort: Cohort
+    exam: Exam
+    question: ExamQuestion
+    deployment: ExamDeployment
+    url: str
+    error_401: str
+    error_403: str
+    error_400: str
+    error_404: str
+    error_409: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.student = User.objects.create_user(
+            email="create_student@test.com",
+            password="test1234!",
+            name="제출학생",
+            nickname="c_student",
+            phone_number="010-5555-5555",
+            is_active=True,
+            role="STUDENT",
+        )
+        cls.normal_user = User.objects.create_user(
+            email="create_normal@test.com",
+            password="test1234!",
+            name="일반유저",
+            nickname="c_normal",
+            phone_number="010-6666-6666",
+            is_active=True,
+            role="USER",
+        )
+
+        cls.course = Course.objects.create(name="백엔드", tag="WEB")
+        cls.subject = Subject.objects.create(
+            course=cls.course,
+            title="Django",
+            number_of_days=30,
+            number_of_hours=60,
+        )
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date="2024-01-01",
+            end_date="2024-12-31",
+        )
+        cls.exam = Exam.objects.create(subject=cls.subject, title="Django 테스트")
+        cls.question = ExamQuestion.objects.create(
+            exam=cls.exam,
+            question="Django는 Python 웹 프레임워크이다",
+            type="ox",
+            answer=["O"],
+            point=10,
+            explanation="맞습니다.",
+        )
+        cls.deployment = ExamDeployment.objects.create(
+            exam=cls.exam,
+            cohort=cls.cohort,
+            access_code="create-access-code",
+            open_at="2024-01-01T00:00:00Z",
+            close_at="2024-12-31T23:59:59Z",
+            questions_snapshot_json=[
+                {
+                    "id": cls.question.id,
+                    "type": "ox",
+                    "question": "Django는 Python 웹 프레임워크이다",
+                    "answer": ["O"],
+                    "point": 10,
+                    "explanation": "맞습니다.",
+                }
+            ],
+        )
+
+        cls.url = reverse("user-exam-submission-create")
+        cls.error_401 = "자격 인증 데이터가 제공되지 않았습니다."
+        cls.error_403 = "권한이 없습니다."
+        cls.error_400 = "유효하지 않은 시험 응시 세션입니다."
+        cls.error_404 = "해당 시험 정보를 찾을 수 없습니다."
+        cls.error_409 = "이미 제출된 시험입니다."
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    def get_valid_data(self) -> dict[str, Any]:
+        return {
+            "deployment_id": self.deployment.id,
+            "started_at": "2024-01-01T10:00:00Z",
+            "cheating_count": 0,
+            "answers": [
+                {
+                    "question_id": self.question.id,
+                    "type": "ox",
+                    "submitted_answer": "O",
+                }
+            ],
+        }
+
+    # 권한
+    def test_create_submission_as_student(self) -> None:
+        self.client.force_authenticate(user=self.student)
+        response = self.client.post(self.url, self.get_valid_data(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+
+    def test_create_submission_as_anonymous(self) -> None:
+        response = self.client.post(self.url, self.get_valid_data(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data.get("error_detail"), self.error_401)
+
+    def test_create_submission_as_normal_user(self) -> None:
+        self.client.force_authenticate(user=self.normal_user)
+        response = self.client.post(self.url, self.get_valid_data(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data.get("error_detail"), self.error_403)
+
+    # 제출 성공
+    def test_create_submission_success(self) -> None:
+        self.client.force_authenticate(user=self.student)
+        response = self.client.post(self.url, self.get_valid_data(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_201_CREATED)
+        self.assertIn("submission_id", response.data)
+        self.assertEqual(response.data["score"], 10)
+        self.assertEqual(response.data["correct_answer_count"], 1)
+        self.assertEqual(response.data["redirect_url"], f"/exam/result/{response.data['submission_id']}")
+
+    # 400
+    def test_create_submission_invalid_data(self) -> None:
+        self.client.force_authenticate(user=self.student)
+        response = self.client.post(self.url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data.get("error_detail"), self.error_400)
+
+    # 404
+    def test_create_submission_deployment_not_found(self) -> None:
+        self.client.force_authenticate(user=self.student)
+        data = self.get_valid_data()
+        data["deployment_id"] = 99999
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.data.get("error_detail"), self.error_404)
+
+    # 409
+    def test_create_submission_already_exists(self) -> None:
+        ExamSubmission.objects.create(
+            submitter=self.student,
+            deployment=self.deployment,
+            started_at=timezone.now(),
+            score=10,
+            correct_answer_count=1,
+        )
+        self.client.force_authenticate(user=self.student)
+        response = self.client.post(self.url, self.get_valid_data(), format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data.get("error_detail"), self.error_409)

--- a/apps/exams/tests/test_user_exam_submission.py
+++ b/apps/exams/tests/test_user_exam_submission.py
@@ -366,7 +366,7 @@ class TestUserExamSubmissionCreate(APITestCase):
         self.assertIn("submission_id", response.data)
         self.assertEqual(response.data["score"], 10)
         self.assertEqual(response.data["correct_answer_count"], 1)
-        self.assertEqual(response.data["redirect_url"], f"/exam/result/{response.data['submission_id']}")
+        self.assertEqual(response.data["redirect_url"], f"/quiz/{response.data['submission_id']}/result")
 
     # 400
     def test_create_submission_invalid_data(self) -> None:

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -6,7 +6,10 @@ from apps.exams.views.exam_deployment_view import (
     ExamDeploymentListView,
     ExamDeploymentStatusView,
 )
-from apps.exams.views.user_exam_submission_view import UserExamSubmissionCreateView, UserExamSubmissionGetView
+from apps.exams.views.user_exam_submission_view import (
+    UserExamSubmissionCreateView,
+    UserExamSubmissionGetView,
+)
 
 urlpatterns = [
     path("submissions/", UserExamSubmissionCreateView.as_view(), name="user-exam-submission-create"),

--- a/apps/exams/urls.py
+++ b/apps/exams/urls.py
@@ -6,9 +6,10 @@ from apps.exams.views.exam_deployment_view import (
     ExamDeploymentListView,
     ExamDeploymentStatusView,
 )
-from apps.exams.views.user_exam_submission_view import UserExamSubmissionGetView
+from apps.exams.views.user_exam_submission_view import UserExamSubmissionCreateView, UserExamSubmissionGetView
 
 urlpatterns = [
+    path("submissions/", UserExamSubmissionCreateView.as_view(), name="user-exam-submission-create"),
     path("submissions/<int:submission_id>", UserExamSubmissionGetView.as_view(), name="user-exam-submission-get"),
     path("deployments", ExamDeploymentListView.as_view(), name="deployment"),
     path("deployments/<int:deployment_id>/check-code", ExamDeploymentCheckCodeView.as_view(), name="deployment-code"),

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -8,11 +8,22 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
+from apps.exams.exceptions.admin_exam_submission_exception import (
+    SubmissionConflictError,
+    SubmissionDeleteNotFoundError,
+    SubmissionNotFoundError,
+)
 from apps.exams.serializers.admin_exam_submission_serializer import (
+    AdminExamSubmissionDetailSerializer,
     AdminExamSubmissionListQuerySerializer,
     AdminExamSubmissionListSerializer,
+    AdminExamSubmissionPathSerializer,
 )
-from apps.exams.services.admin_exam_submission_service import get_submission_list
+from apps.exams.services.admin_exam_submission_service import (
+    delete_submission,
+    get_submission_detail,
+    get_submission_list,
+)
 
 
 class ExamSubmissionPagination(BasePageNumberPagination):
@@ -41,3 +52,45 @@ class AdminExamSubmissionView(APIView):
 
         serializer = AdminExamSubmissionListSerializer(paginated, many=True)
         return paginator.get_paginated_response(serializer.data)
+
+
+class AdminExamSubmissionDetailView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
+        if request.authenticators and not request.successful_authenticator:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        if request.method == "GET":
+            raise PermissionDenied("쪽지시험 응시 상세 조회 권한이 없습니다.")
+        if request.method == "DELETE":
+            raise PermissionDenied("쪽지시험 응시 내역 삭제 권한이 없습니다.")
+        raise PermissionDenied("권한이 없습니다.")
+
+    def get(self, request: Request, submission_id: int) -> Response:
+        path_serializer = AdminExamSubmissionPathSerializer(data={"submission_id": submission_id})
+        if not path_serializer.is_valid():
+            return Response({"error_detail": "유효하지 않은 상세 조회 요청입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            submission = get_submission_detail(submission_id)
+        except SubmissionNotFoundError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+
+        serializer = AdminExamSubmissionDetailSerializer(submission)
+        return Response(serializer.data, status=status.HTTP_200_OK)
+
+    def delete(self, request: Request, submission_id: int) -> Response:
+        path_serializer = AdminExamSubmissionPathSerializer(data={"submission_id": submission_id})
+        if not path_serializer.is_valid():
+            return Response(
+                {"error_detail": "유효하지 않은 응시 내역 삭제 요청입니다."}, status=status.HTTP_400_BAD_REQUEST
+            )
+
+        try:
+            delete_submission(submission_id)
+        except SubmissionDeleteNotFoundError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except SubmissionConflictError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        return Response({"submission_id": submission_id}, status=status.HTTP_200_OK)

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -1,5 +1,6 @@
 from typing import Never
 
+from drf_spectacular.utils import OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.pagination import PageNumberPagination as BasePageNumberPagination
@@ -40,6 +41,16 @@ class AdminExamSubmissionView(APIView):
             raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
         raise PermissionDenied("쪽지시험 응시 내역 조회 권한이 없습니다.")
 
+    @extend_schema(
+        tags=["admin-exams"],
+        summary="쪽지시험 응시내역 목록 조회",
+        responses={
+            200: AdminExamSubmissionListSerializer,
+            400: OpenApiResponse(description="유효하지 않은 조회 요청입니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="쪽지시험 응시 내역 조회 권한이 없습니다."),
+        },
+    )
     def get(self, request: Request) -> Response:
         query_serializer = AdminExamSubmissionListQuerySerializer(data=request.query_params)
         if not query_serializer.is_valid():
@@ -66,6 +77,17 @@ class AdminExamSubmissionDetailView(APIView):
             raise PermissionDenied("쪽지시험 응시 내역 삭제 권한이 없습니다.")
         raise PermissionDenied("권한이 없습니다.")
 
+    @extend_schema(
+        tags=["admin-exams"],
+        summary="쪽지시험 응시내역 상세 조회",
+        responses={
+            200: AdminExamSubmissionDetailSerializer,
+            400: OpenApiResponse(description="유효하지 않은 상세 조회 요청입니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="쪽지시험 응시 상세 조회 권한이 없습니다."),
+            404: OpenApiResponse(description="해당 응시 내역을 찾을 수 없습니다."),
+        },
+    )
     def get(self, request: Request, submission_id: int) -> Response:
         path_serializer = AdminExamSubmissionPathSerializer(data={"submission_id": submission_id})
         if not path_serializer.is_valid():
@@ -79,6 +101,18 @@ class AdminExamSubmissionDetailView(APIView):
         serializer = AdminExamSubmissionDetailSerializer(submission)
         return Response(serializer.data, status=status.HTTP_200_OK)
 
+    @extend_schema(
+        tags=["admin-exams"],
+        summary="쪽지시험 응시내역 삭제",
+        responses={
+            200: OpenApiResponse(description="삭제된 응시내역 ID"),
+            400: OpenApiResponse(description="유효하지 않은 응시 내역 삭제 요청입니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="쪽지시험 응시 내역 삭제 권한이 없습니다."),
+            404: OpenApiResponse(description="삭제할 응시 내역을 찾을 수 없습니다."),
+            409: OpenApiResponse(description="응시 내역 삭제 처리 중 충돌이 발생했습니다."),
+        },
+    )
     def delete(self, request: Request, submission_id: int) -> Response:
         path_serializer = AdminExamSubmissionPathSerializer(data={"submission_id": submission_id})
         if not path_serializer.is_valid():

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -2,7 +2,7 @@ from typing import Never
 
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
-from rest_framework.pagination import PageNumberPagination
+from rest_framework.pagination import PageNumberPagination as BasePageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
@@ -13,6 +13,12 @@ from apps.exams.serializers.admin_exam_submission_serializer import (
     AdminExamSubmissionListSerializer,
 )
 from apps.exams.services.admin_exam_submission_service import get_submission_list
+
+
+class ExamSubmissionPagination(BasePageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
 
 
 class AdminExamSubmissionView(APIView):
@@ -30,10 +36,7 @@ class AdminExamSubmissionView(APIView):
 
         submissions = get_submission_list(query_serializer.validated_data)
 
-        if not submissions.exists():
-            return Response({"error_detail": "조회된 응시 내역이 없습니다."}, status=status.HTTP_404_NOT_FOUND)
-
-        paginator = PageNumberPagination()
+        paginator = ExamSubmissionPagination()
         paginated = paginator.paginate_queryset(submissions, request)
 
         serializer = AdminExamSubmissionListSerializer(paginated, many=True)

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -44,6 +44,7 @@ class AdminExamSubmissionView(APIView):
     @extend_schema(
         tags=["admin-exams"],
         summary="쪽지시험 응시내역 목록 조회",
+        parameters=[AdminExamSubmissionListQuerySerializer],
         responses={
             200: AdminExamSubmissionListSerializer,
             400: OpenApiResponse(description="유효하지 않은 조회 요청입니다."),

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -1,0 +1,37 @@
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.permissions import IsRoleAdminUser
+from apps.exams.serializers.admin_exam_submission_serializer import (
+    AdminExamSubmissionListQuerySerializer,
+    AdminExamSubmissionListSerializer,
+)
+from apps.exams.services.admin_exam_submission_service import get_submission_list
+
+
+class AdminExamSubmissionView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request, message=None, code=None):
+        if request.authenticators and not request.successful_authenticator:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("쪽지시험 응시 내역 조회 권한이 없습니다.")
+
+    def get(self, request):
+        query_serializer = AdminExamSubmissionListQuerySerializer(data=request.query_params)
+        if not query_serializer.is_valid():
+            return Response({"error_detail": "유효하지 않은 조회 요청입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        submissions = get_submission_list(query_serializer.validated_data)
+
+        if not submissions.exists():
+            return Response({"error_detail": "조회된 응시 내역이 없습니다."}, status=status.HTTP_404_NOT_FOUND)
+
+        paginator = PageNumberPagination()
+        paginated = paginator.paginate_queryset(submissions, request)
+
+        serializer = AdminExamSubmissionListSerializer(paginated, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/apps/exams/views/admin_exam_submission_view.py
+++ b/apps/exams/views/admin_exam_submission_view.py
@@ -1,6 +1,9 @@
+from typing import Never
+
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
@@ -15,12 +18,12 @@ from apps.exams.services.admin_exam_submission_service import get_submission_lis
 class AdminExamSubmissionView(APIView):
     permission_classes = [IsRoleAdminUser]
 
-    def permission_denied(self, request, message=None, code=None):
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
         if request.authenticators and not request.successful_authenticator:
             raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
         raise PermissionDenied("쪽지시험 응시 내역 조회 권한이 없습니다.")
 
-    def get(self, request):
+    def get(self, request: Request) -> Response:
         query_serializer = AdminExamSubmissionListQuerySerializer(data=request.query_params)
         if not query_serializer.is_valid():
             return Response({"error_detail": "유효하지 않은 조회 요청입니다."}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/exams/views/user_exam_submission_view.py
+++ b/apps/exams/views/user_exam_submission_view.py
@@ -8,12 +8,20 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStudentUser
-from apps.exams.exceptions.exam_submission_exception import UserSubmissionNotFound
+from apps.exams.exceptions.exam_submission_exception import (
+    DeploymentNotFound,
+    SubmissionAlreadyExists,
+    UserSubmissionNotFound,
+)
 from apps.exams.serializers.user_exam_submission_serializer import (
+    UserExamSubmissionCreateSerializer,
     UserExamSubmissionExtendSchemaSerializer,
     UserExamSubmissionGetSerializer,
 )
-from apps.exams.services.user_exam_submission_service import get_submission_detail
+from apps.exams.services.user_exam_submission_service import (
+    create_submission,
+    get_submission_detail,
+)
 
 
 class UserExamSubmissionGetView(APIView):
@@ -43,3 +51,35 @@ class UserExamSubmissionGetView(APIView):
             return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
         serializer = UserExamSubmissionGetSerializer(submission)
         return Response(serializer.data, status=status.HTTP_200_OK)
+
+
+class UserExamSubmissionCreateView(APIView):
+    permission_classes = [IsStudentUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user.is_authenticated:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("권한이 없습니다.")
+
+    def post(self, request: Request) -> Response:
+        serializer = UserExamSubmissionCreateSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": "유효하지 않은 시험 응시 세션입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            assert request.user.id is not None
+            submission = create_submission(request.user.id, serializer.validated_data)
+        except DeploymentNotFound as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        except SubmissionAlreadyExists as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_409_CONFLICT)
+
+        return Response(
+            {
+                "submission_id": submission.id,
+                "score": submission.score,
+                "correct_answer_count": submission.correct_answer_count,
+                "redirect_url": f"/exam/result/{submission.id}",
+            },
+            status=status.HTTP_201_CREATED,
+        )

--- a/apps/exams/views/user_exam_submission_view.py
+++ b/apps/exams/views/user_exam_submission_view.py
@@ -93,7 +93,7 @@ class UserExamSubmissionCreateView(APIView):
                 "submission_id": submission.id,
                 "score": submission.score,
                 "correct_answer_count": submission.correct_answer_count,
-                "redirect_url": f"/exam/result/{submission.id}",
+                "redirect_url": f"/quiz/{submission.id}/result",
             },
             status=status.HTTP_201_CREATED,
         )

--- a/apps/exams/views/user_exam_submission_view.py
+++ b/apps/exams/views/user_exam_submission_view.py
@@ -14,6 +14,7 @@ from apps.exams.exceptions.exam_submission_exception import (
     UserSubmissionNotFound,
 )
 from apps.exams.serializers.user_exam_submission_serializer import (
+    UserExamSubmissionCreateResponseSerializer,
     UserExamSubmissionCreateSerializer,
     UserExamSubmissionExtendSchemaSerializer,
     UserExamSubmissionGetSerializer,
@@ -61,6 +62,19 @@ class UserExamSubmissionCreateView(APIView):
             raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
         raise PermissionDenied("권한이 없습니다.")
 
+    @extend_schema(
+        tags=["exams"],
+        summary="쪽지시험 응시 제출 API",
+        request=UserExamSubmissionCreateSerializer,
+        responses={
+            201: UserExamSubmissionCreateResponseSerializer,
+            400: OpenApiResponse(description="유효하지 않은 시험 응시 세션입니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="권한이 없습니다."),
+            404: OpenApiResponse(description="해당 시험 정보를 찾을 수 없습니다."),
+            409: OpenApiResponse(description="이미 제출된 시험입니다."),
+        },
+    )
     def post(self, request: Request) -> Response:
         serializer = UserExamSubmissionCreateSerializer(data=request.data)
         if not serializer.is_valid():


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 쪽지시험 응시내역 API 구현 (어드민 목록/상세/삭제, 사용자 제출)

## 📄 상세 내용
- [x] 어드민 응시내역 목록 조회 API PR 피드백 반영
- [x] 어드민 응시내역 상세 조회 API 구현
- [x] 어드민 응시내역 삭제 API 구현
- [x] 사용자 쪽지시험 응시 제출 API 구현
- [x] URL 등록 (submissions/, submissions/<id>/)
- [x] 테스트 코드 작성 (34개)

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
