### PR TITLE
✨ feat: 이메일 찾기 기능 구현

### DIFF
--- a/apps/users/serializers/find_email_serializer.py
+++ b/apps/users/serializers/find_email_serializer.py
@@ -1,0 +1,8 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class FindEmailSerializer(serializers.Serializer[Any]):
+    sms_token = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})
+    name = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})

--- a/apps/users/serializers/find_email_serializer.py
+++ b/apps/users/serializers/find_email_serializer.py
@@ -8,5 +8,5 @@ class FindEmailSerializer(serializers.Serializer[Any]):
     name = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})
 
 
-class FindEmailResponseSerializer(serializers.Serializer):
+class FindEmailResponseSerializer(serializers.Serializer[Any]):
     email = serializers.CharField()

--- a/apps/users/serializers/find_email_serializer.py
+++ b/apps/users/serializers/find_email_serializer.py
@@ -6,3 +6,7 @@ from rest_framework import serializers
 class FindEmailSerializer(serializers.Serializer[Any]):
     sms_token = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})
     name = serializers.CharField(required=True, error_messages={"required": "이 필드는 필수 항목입니다."})
+
+
+class FindEmailResponseSerializer(serializers.Serializer):
+    email = serializers.CharField()

--- a/apps/users/services/find_email_service.py
+++ b/apps/users/services/find_email_service.py
@@ -1,0 +1,60 @@
+from typing import Any
+
+from django.core.cache import cache
+from rest_framework.exceptions import ValidationError
+
+from apps.users.models import User
+from apps.users.utils.purpose_enum import SmsPurpose
+
+FIND_EMAIL = SmsPurpose.FIND_EMAIL.value
+
+
+def email_mask(email: str) -> str:
+
+    username, domain = email.rsplit("@", 1)
+    domain_name, domain_ext = domain.split(".", 1)
+
+    # username 마스킹: 첫 글자 + '*' + 마지막 글자
+    username_masked = username[0] + "*" * (len(username) - 2) + username[-1]
+
+    # domain 마스킹: 첫 글자 + '*' + 마지막 2글자
+    domain_masked = domain_name[0] + "*" * (len(domain_name) - 3) + domain_name[-2:]
+
+    masked_email = f"{username_masked}@{domain_masked}.{domain_ext}"
+
+    return masked_email
+
+
+def find_email_service(validated_data: dict[str, Any]) -> str:
+    """
+    sms 인증 토큰을 받아 redis cache에
+    저장된 phone_number,purpose꺼내서 유저 정보와 용도 확인후
+    유저 이메일 제공
+    """
+
+    sms_token = validated_data["sms_token"]
+    name = validated_data["name"]
+
+    sms_key = f"sms_verify_token_{sms_token}"
+    # 캐쉬에 저장된 용도, 이메일
+    sms_data = cache.get(sms_key)
+
+    # 토큰 유효한지 확인
+    if not sms_data:
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+
+    if FIND_EMAIL != sms_data.get("purpose"):
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+    phone_number = sms_data.get("phone_number")
+
+    # 이메일 조회
+    try:
+        user = User.objects.get(name=name, phone_number=phone_number)
+        email = user.email
+        cache.delete(sms_key)
+        masked_email = email_mask(email)
+        return masked_email
+
+    # 동록된 전화번호와 이름이 아닐경우
+    except User.DoesNotExist:
+        raise ValidationError("해당 정보를 가진 사용자를 찾을 수 없습니다.")

--- a/apps/users/services/find_email_service.py
+++ b/apps/users/services/find_email_service.py
@@ -6,8 +6,6 @@ from rest_framework.exceptions import ValidationError
 from apps.users.models import User
 from apps.users.utils.purpose_enum import SmsPurpose
 
-FIND_EMAIL = SmsPurpose.FIND_EMAIL.value
-
 
 def email_mask(email: str) -> str:
 
@@ -43,8 +41,10 @@ def find_email_service(validated_data: dict[str, Any]) -> str:
     if not sms_data:
         raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
 
-    if FIND_EMAIL != sms_data.get("purpose"):
+    purpose = SmsPurpose(sms_data.get("purpose"))
+    if purpose != SmsPurpose.FIND_EMAIL:
         raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+
     phone_number = sms_data.get("phone_number")
 
     # 이메일 조회

--- a/apps/users/tests/test_find_email.py
+++ b/apps/users/tests/test_find_email.py
@@ -51,7 +51,7 @@ class FindEmailAPITestCase(IsolatedRedisTestClient):
 
         # 상태 코드 및 메시지 확인
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertEqual(response.data, self.masked_email)
+        self.assertEqual(response.data, {"email": self.masked_email})
         # 사용된 Redis 토큰 삭제 확인
         self.assertIsNone(cache.get(self.cache_key))
 

--- a/apps/users/tests/test_find_email.py
+++ b/apps/users/tests/test_find_email.py
@@ -1,0 +1,83 @@
+import uuid
+
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+
+from apps.core.utils.isolated_cache_testcase import IsolatedRedisTestClient
+from apps.users.models import User
+from apps.users.utils.purpose_enum import SmsPurpose
+
+
+class FindEmailAPITestCase(IsolatedRedisTestClient):
+    # 테스트에 사용할 유저 정보
+    user: User
+    name: str = "테스터"
+    masked_email: str = "t**t@c***ng.com"
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """테스트 전체에서 공통으로 사용할 유저 생성"""
+        cls.user = User.objects.create_user(
+            email="test@coding.com",
+            password="testfinde12!@",
+            name=cls.name,
+            nickname="tester",
+            phone_number="010-9999-8888",
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 테스트에 사용할 API URL 및 토큰 설정
+        self.url: str = reverse("users:find_email")
+        self.sms_token: str = f"token_{uuid.uuid4().hex}"
+        self.cache_key: str = f"sms_verify_token_{self.sms_token}"
+
+        # 기본 유효 페이로드
+        self.valid_payload = {
+            "sms_token": self.sms_token,
+            "name": self.name,
+        }
+
+    def set_cache_data(self, purpose: str = SmsPurpose.FIND_EMAIL.value) -> None:
+        """Redis 캐시에 인증 데이터를 주입하는 헬퍼 메서드"""
+        cache.set(self.cache_key, {"phone_number": self.user.phone_number, "purpose": purpose}, timeout=300)
+
+    def test_find_email_success(self) -> None:
+        """정상적인 토큰으로 이메일 확인 성공 (200) 테스트"""
+        self.set_cache_data()
+
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        # 상태 코드 및 메시지 확인
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data, self.masked_email)
+        # 사용된 Redis 토큰 삭제 확인
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_find_email_with_invalid_token_returns_400(self) -> None:
+        """존재하지 않거나 만료된 토큰 사용 시 400 반환 테스트"""
+        # 캐시 설정 없이 요청
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_find_email_with_wrong_purpose_returns_400(self) -> None:
+        """이메일 찾기용이 아닌 다른 용도의 토큰(예: 회원가입용) 사용 시 400 반환"""
+        # SIGNUP 용도
+        self.set_cache_data(purpose=SmsPurpose.SIGNUP.value)
+
+        response = self.client.post(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_find_email_missing_fields_returns_400(self) -> None:
+        """필수 필드 누락 시 400 반환 테스트"""
+        data = {"sms_token": self.sms_token}  # 이름 필드 누락
+
+        response = self.client.post(self.url, data, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)

--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -15,4 +15,5 @@ urlpatterns = [
     path("", include("apps.users.urls.user_login_url")),
     path("", include("apps.users.urls.find_password_url")),
     path("", include("apps.users.urls.change_phone_url")),
+    path("", include("apps.users.urls.find_email_url")),
 ]

--- a/apps/users/urls/find_email_url.py
+++ b/apps/users/urls/find_email_url.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.users.views.find_email_view import FindEmailView
+
+urlpatterns = [
+    path("find-email", FindEmailView.as_view(), name="find_email"),
+]

--- a/apps/users/views/find_email_view.py
+++ b/apps/users/views/find_email_view.py
@@ -6,7 +6,10 @@ from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
-from apps.users.serializers.find_email_serializer import FindEmailSerializer
+from apps.users.serializers.find_email_serializer import (
+    FindEmailResponseSerializer,
+    FindEmailSerializer,
+)
 from apps.users.services.find_email_service import find_email_service
 
 
@@ -30,8 +33,8 @@ class FindEmailView(APIView):
 
         try:
             masked_email = find_email_service(serializer.validated_data)
-
-            return Response(masked_email, status=status.HTTP_200_OK)
+            response_serializer = FindEmailResponseSerializer({"email": masked_email})
+            return Response(response_serializer.data, status=status.HTTP_200_OK)
 
         except ValidationError as e:
             return Response({"error_detail": e.detail}, status=status.HTTP_400_BAD_REQUEST)

--- a/apps/users/views/find_email_view.py
+++ b/apps/users/views/find_email_view.py
@@ -1,0 +1,37 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import AllowAny
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.serializers.find_email_serializer import FindEmailSerializer
+from apps.users.services.find_email_service import find_email_service
+
+
+class FindEmailView(APIView):
+    permission_classes = [AllowAny]
+
+    @extend_schema(
+        tags=["accounts"],
+        summary="이메일 찾기 api",
+        description="sms 인증 후 발급받은 토큰을 활용하여 이메일 찾기",
+        request=FindEmailSerializer,
+        responses={
+            200: OpenApiResponse(description="이메일 찾기 성공"),
+            400: OpenApiResponse(description="유효성 검사 실패"),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = FindEmailSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        try:
+            masked_email = find_email_service(serializer.validated_data)
+
+            return Response(masked_email, status=status.HTTP_200_OK)
+
+        except ValidationError as e:
+            return Response({"error_detail": e.detail}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- sms 인증 성공 시 발급 받은 토큰을 사용하여 캐시에 저장된 정보로 이용자 확인
- 유저 정보에서 이메일 정보를 가져와서 마스킹 처리후 응답

# Conflicts:
#	apps/users/urls/__init__.py

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: sms 인증 토큰을 활용한 유저 이메일 찾기 API 구현

## 📄 상세 내용
- [ ] sms인증 토큰(email_token)으로  Redis 저장된  번호를 추출하여 유저를 확인 
- [ ] 유저 정보에서 이메일 정보를 가져와서 마스킹 처리 후 응답

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
