### PR TITLE
✨ feat: 질의 응답 목록 조회 API 구현

### DIFF
--- a/apps/qna/schemas/question_schemas.py
+++ b/apps/qna/schemas/question_schemas.py
@@ -1,4 +1,5 @@
 from drf_spectacular.utils import (
+    OpenApiParameter,
     OpenApiResponse,
     extend_schema,
 )
@@ -6,6 +7,7 @@ from drf_spectacular.utils import (
 from apps.qna.serializers.question_serializers import (
     QuestionCreateResponseSerializer,
     QuestionCreateSerializer,
+    QuestionListItemSerializer,
 )
 
 # ── 질문 등록 ──────────────────────────────────────────────────────
@@ -20,5 +22,63 @@ question_create_schema = extend_schema(
         400: OpenApiResponse(description="유효하지 않은 질문 등록 요청입니다."),
         401: OpenApiResponse(description="로그인한 수강생만 질문을 등록할 수 있습니다."),
         403: OpenApiResponse(description="질문 등록 권한이 없습니다."),
+    },
+)
+
+# ── 질문 목록 조회 ──────────────────────────────────────────────────
+
+question_list_schema = extend_schema(
+    tags=["Qna"],
+    summary="질문 목록 조회",
+    description="질의응답 목록을 조회합니다. 검색, 카테고리 필터, 답변 상태 필터, 정렬 기능을 제공합니다.",
+    parameters=[
+        OpenApiParameter(
+            name="page",
+            type=int,
+            location=OpenApiParameter.QUERY,
+            description="페이지 번호 (기본값: 1)",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="page_size",
+            type=int,
+            location=OpenApiParameter.QUERY,
+            description="페이지당 항목 수 (기본값: 10, 최대: 100)",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="search_keyword",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="검색 키워드 (제목 검색)",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="category_id",
+            type=int,
+            location=OpenApiParameter.QUERY,
+            description="카테고리 ID (상위 카테고리 선택 시 하위 카테고리 포함)",
+            required=False,
+        ),
+        OpenApiParameter(
+            name="answer_status",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="답변 상태 필터 (answered: 답변 있음, unanswered: 답변 없음)",
+            required=False,
+            enum=["answered", "unanswered"],
+        ),
+        OpenApiParameter(
+            name="sort",
+            type=str,
+            location=OpenApiParameter.QUERY,
+            description="정렬 기준 (latest: 최신순, oldest: 오래된순, views: 조회수순)",
+            required=False,
+            enum=["latest", "oldest", "views"],
+        ),
+    ],
+    responses={
+        200: QuestionListItemSerializer(many=True),
+        400: OpenApiResponse(description="유효하지 않은 목록 조회 요청입니다."),
     },
 )

--- a/apps/qna/serializers/question_serializers.py
+++ b/apps/qna/serializers/question_serializers.py
@@ -26,3 +26,29 @@ class QuestionCreateSerializer(serializers.Serializer[Any]):
 class QuestionCreateResponseSerializer(serializers.Serializer[Any]):
     message = serializers.CharField()
     question_id = serializers.IntegerField()
+
+
+class QuestionListCategorySerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    depth = serializers.IntegerField()
+    names = serializers.ListField(child=serializers.CharField())
+
+
+class QuestionListAuthorSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    nickname = serializers.CharField()
+    profile_img_url = serializers.CharField(allow_null=True)
+    course_name = serializers.CharField(allow_null=True)
+    cohort_number = serializers.IntegerField(allow_null=True)
+
+
+class QuestionListItemSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    category = QuestionListCategorySerializer()
+    author = QuestionListAuthorSerializer()
+    title = serializers.CharField()
+    content_preview = serializers.CharField()
+    answer_count = serializers.IntegerField()
+    view_count = serializers.IntegerField()
+    created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+    thumbnail_img_url = serializers.CharField(allow_null=True)

--- a/apps/qna/services/question_services.py
+++ b/apps/qna/services/question_services.py
@@ -1,7 +1,8 @@
 from django.db import transaction
+from django.db.models import Count, OuterRef, Prefetch, QuerySet, Subquery
 
 from apps.qna.models.question_models import Question, QuestionCategory, QuestionImage
-from apps.users.models import User
+from apps.users.models import CohortStudents, User
 
 
 class QuestionService:
@@ -27,3 +28,130 @@ class QuestionService:
             QuestionImage.objects.bulk_create([QuestionImage(question=question, img_url=url) for url in img_urls])
 
         return question
+
+
+def _get_category_info(category: QuestionCategory) -> dict[str, object]:
+    """카테고리 대/중/소 name 리스트와 depth 반환"""
+    chain: list[str] = []
+    current: QuestionCategory | None = category
+    while current is not None:
+        chain.append(current.name)
+        current = current.parent
+
+    names = list(reversed(chain))  # 대 → 중 → 소 순서
+
+    return {
+        "id": category.id,
+        "depth": len(names),  # 대=0, 중=1, 소=2
+        "names": names,
+    }
+
+
+class QuestionListService:
+
+    @staticmethod
+    def get_question_list(
+        *,
+        page: int,
+        page_size: int,
+        search_keyword: str | None = None,
+        category_id: int | None = None,
+        answer_status: str | None = None,
+        sort: str = "latest",
+    ) -> tuple[QuerySet[Question], int]:
+
+        # 첫 번째 이미지 서브쿼리
+        first_image_subquery = Subquery(
+            QuestionImage.objects.filter(question=OuterRef("pk")).order_by("id").values("img_url")[:1]
+        )
+
+        qs = (
+            Question.objects.select_related(
+                "category__parent__parent",
+                "author",
+            )
+            .prefetch_related(
+                Prefetch(
+                    "author__cohort_students",
+                    queryset=CohortStudents.objects.select_related("cohort__course"),
+                )
+            )
+            .annotate(
+                answer_count=Count("answer", distinct=True),
+                thumbnail_img_url=first_image_subquery,
+            )
+        )
+
+        # 검색 필터
+        if search_keyword:
+            qs = qs.filter(title__icontains=search_keyword)
+
+        # 카테고리 필터 (상위 카테고리 선택 시 하위 카테고리 포함)
+        if category_id:
+            category_ids = QuestionListService._get_descendant_category_ids(category_id)
+            qs = qs.filter(category_id__in=category_ids)
+
+        # 답변 상태 필터
+        if answer_status == "answered":
+            qs = qs.filter(answer_count__gt=0)
+        elif answer_status == "unanswered":
+            qs = qs.filter(answer_count=0)
+
+        # 정렬
+        order_map = {
+            "latest": "-created_at",
+            "oldest": "created_at",
+            "views": "-view_count",
+        }
+        qs = qs.order_by(order_map.get(sort, "-created_at"))
+
+        total_count = qs.count()
+        offset = (page - 1) * page_size
+        questions = qs[offset : offset + page_size]
+
+        return questions, total_count
+
+    @staticmethod
+    def _get_descendant_category_ids(category_id: int) -> list[int]:
+        """선택된 카테고리 + 모든 하위 카테고리 id 반환 (쿼리 1번)"""
+        # 전체 카테고리를 한 번에 가져와서 메모리에서 트리 탐색
+        all_categories = QuestionCategory.objects.values_list("id", "parent_id")
+
+        ids = {category_id}
+        changed = True
+        while changed:
+            changed = False
+            for cat_id, parent_id in all_categories:
+                if parent_id in ids and cat_id not in ids:
+                    ids.add(cat_id)
+                    changed = True
+
+        return list(ids)
+
+    @staticmethod
+    def build_result(question: Question) -> dict[str, object]:
+        author = question.author
+        category = question.category
+
+        # course_name, cohort_number 조회 (prefetch된 데이터 사용)
+        cohort_student = author.cohort_students.first() if hasattr(author, "cohort_students") else None
+        course_name = cohort_student.cohort.course.name if cohort_student and cohort_student.cohort else None
+        cohort_number = cohort_student.cohort.number if cohort_student and cohort_student.cohort else None
+
+        return {
+            "id": question.id,
+            "category": _get_category_info(category),
+            "author": {
+                "id": author.id,
+                "nickname": author.nickname,
+                "profile_img_url": getattr(author, "profile_img_url", None),
+                "course_name": course_name,
+                "cohort_number": cohort_number,
+            },
+            "title": question.title,
+            "content_preview": question.content[:100],
+            "answer_count": question.answer_count,  # type: ignore[attr-defined]
+            "view_count": question.view_count,
+            "created_at": question.created_at,
+            "thumbnail_img_url": question.thumbnail_img_url,  # type: ignore[attr-defined]
+        }

--- a/apps/qna/tests/test_questions/test_questions_list.py
+++ b/apps/qna/tests/test_questions/test_questions_list.py
@@ -1,0 +1,402 @@
+from typing import Any
+
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.qna.models.question_models import Question, QuestionCategory, QuestionImage
+from apps.users.models import User
+
+URL = "/api/v1/qna/questions"
+
+
+class QuestionListAPIViewTest(APITestCase):
+    """GET /api/v1/qna/questions - 질문 목록 조회 API 테스트"""
+
+    # ── 클래스 레벨 타입 어노테이션 ──────────────────────────────────
+    student_user: User
+    other_student: User
+    general_user: User
+    large_category: QuestionCategory
+    medium_category: QuestionCategory
+    small_category: QuestionCategory
+    small_category2: QuestionCategory
+    question1: Question
+    question2: Question
+    question3: Question
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.student_user = User.objects.create_user(
+            email="student@test.com",
+            password="password123!",
+            name="수강생",
+            nickname="st_nick",
+            phone_number="010-1111-1111",
+            gender="male",
+            birthday="2000-01-01",
+            role="STUDENT",
+            is_active=True,
+        )
+        cls.other_student = User.objects.create_user(
+            email="other@test.com",
+            password="password123!",
+            name="다른수강생",
+            nickname="ot_nick",
+            phone_number="010-2222-2222",
+            gender="female",
+            birthday="2000-01-01",
+            role="STUDENT",
+            is_active=True,
+        )
+        cls.general_user = User.objects.create_user(
+            email="general@test.com",
+            password="password123!",
+            name="일반유저",
+            nickname="ge_nick",
+            phone_number="010-3333-3333",
+            gender="male",
+            birthday="1995-01-01",
+            role="GENERAL",
+            is_active=True,
+        )
+
+        # 카테고리 대/중/소 구성
+        cls.large_category = QuestionCategory.objects.create(name="백엔드", parent=None)
+        cls.medium_category = QuestionCategory.objects.create(name="웹프레임워크", parent=cls.large_category)
+        cls.small_category = QuestionCategory.objects.create(name="Django", parent=cls.medium_category)
+        cls.small_category2 = QuestionCategory.objects.create(name="FastAPI", parent=cls.medium_category)
+
+        # 질문 픽스처
+        cls.question1 = Question.objects.create(
+            author=cls.student_user,
+            category=cls.small_category,
+            title="Django ORM 질문",
+            content="Django ORM에서 select_related와 prefetch_related 차이가 궁금합니다.",
+            view_count=10,
+        )
+        cls.question2 = Question.objects.create(
+            author=cls.other_student,
+            category=cls.small_category,
+            title="Django 마이그레이션 질문",
+            content="마이그레이션 충돌 해결 방법이 궁금합니다.",
+            view_count=5,
+        )
+        cls.question3 = Question.objects.create(
+            author=cls.student_user,
+            category=cls.small_category2,
+            title="FastAPI 의존성 주입 질문",
+            content="FastAPI에서 Depends를 활용하는 방법이 궁금합니다.",
+            view_count=20,
+        )
+
+        # question1에만 이미지 추가
+        QuestionImage.objects.create(
+            question=cls.question1,
+            img_url="https://bucket.s3.amazonaws.com/img1.png",
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # ── 헬퍼 ────────────────────────────────────────────────────────
+
+    def _force_login(self, user: User) -> None:
+        self.client.force_authenticate(user=user)
+
+    def _get_result_ids(self, response_data: dict[str, Any]) -> list[int]:
+        return [item["id"] for item in response_data["results"]]
+
+    # ── 성공 케이스 ─────────────────────────────────────────────────
+
+    def test_목록_조회_성공_기본(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", response.data)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+
+    def test_목록_조회_응답_필드_검증(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        item = response.data["results"][0]
+        # 필수 필드 존재 여부 확인
+        for field in [
+            "id",
+            "category",
+            "author",
+            "title",
+            "content_preview",
+            "answer_count",
+            "view_count",
+            "created_at",
+            "thumbnail_img_url",
+        ]:
+            self.assertIn(field, item)
+
+        # category 필드 구조 확인
+        for field in ["id", "depth", "names"]:
+            self.assertIn(field, item["category"])
+
+        # author 필드 구조 확인
+        for field in ["id", "nickname", "profile_img_url"]:
+            self.assertIn(field, item["author"])
+
+    def test_카테고리_depth_소분류는_3(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # question1은 소분류(Django)에 속함
+        result = next(r for r in response.data["results"] if r["id"] == self.question1.id)
+        self.assertEqual(result["category"]["depth"], 3)
+        self.assertEqual(result["category"]["names"], ["백엔드", "웹프레임워크", "Django"])
+
+    def test_thumbnail_img_url_이미지_있는_질문(self) -> None:
+        """이미지가 있는 질문은 첫 번째 이미지 URL 반환"""
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        result = next(r for r in response.data["results"] if r["id"] == self.question1.id)
+        self.assertEqual(result["thumbnail_img_url"], "https://bucket.s3.amazonaws.com/img1.png")
+
+    def test_thumbnail_img_url_이미지_없는_질문은_null(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        result = next(r for r in response.data["results"] if r["id"] == self.question2.id)
+        self.assertIsNone(result["thumbnail_img_url"])
+
+    def test_content_preview_100자_초과시_잘림(self) -> None:
+        long_content = "A" * 200
+        question = Question.objects.create(
+            author=self.student_user,
+            category=self.small_category,
+            title="긴 내용 질문",
+            content=long_content,
+        )
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL)
+
+        result = next(r for r in response.data["results"] if r["id"] == question.id)
+        self.assertEqual(len(result["content_preview"]), 100)
+
+    # ── 페이지네이션 ─────────────────────────────────────────────────
+
+    def test_페이지네이션_page_size_적용(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"page": 1, "page_size": 2})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(len(response.data["results"]), 2)
+
+    def test_페이지네이션_next_url_존재(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"page": 1, "page_size": 2})
+
+        self.assertIsNotNone(response.data["next"])
+
+    def test_페이지네이션_마지막_페이지_next_없음(self) -> None:
+        self._force_login(self.student_user)
+        total = Question.objects.count()
+
+        response = self.client.get(URL, {"page": 1, "page_size": total})
+
+        self.assertIsNone(response.data["next"])
+
+    def test_페이지네이션_첫_페이지_previous_없음(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"page": 1, "page_size": 2})
+
+        self.assertIsNone(response.data["previous"])
+
+    def test_count_전체_질문_수_반환(self) -> None:
+        self._force_login(self.student_user)
+        total = Question.objects.count()
+
+        response = self.client.get(URL)
+
+        self.assertEqual(response.data["count"], total)
+
+    # ── 검색 필터 ────────────────────────────────────────────────────
+
+    def test_search_keyword_제목_검색(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"search_keyword": "ORM"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        self.assertIn(self.question1.id, ids)
+        self.assertNotIn(self.question2.id, ids)
+        self.assertNotIn(self.question3.id, ids)
+
+    def test_search_keyword_결과_없으면_빈_리스트(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"search_keyword": "존재하지않는키워드xyz"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["count"], 0)
+        self.assertEqual(response.data["results"], [])
+
+    # ── 카테고리 필터 ────────────────────────────────────────────────
+
+    def test_category_id_소분류_필터(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"category_id": self.small_category.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        self.assertIn(self.question1.id, ids)
+        self.assertIn(self.question2.id, ids)
+        self.assertNotIn(self.question3.id, ids)  # small_category2 소속
+
+    def test_category_id_중분류_필터_하위_모두_포함(self) -> None:
+        """중분류 선택 시 하위 소분류 질문 모두 포함"""
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"category_id": self.medium_category.id})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        # small_category, small_category2 둘 다 medium_category 하위
+        self.assertIn(self.question1.id, ids)
+        self.assertIn(self.question2.id, ids)
+        self.assertIn(self.question3.id, ids)
+
+    def test_존재하지_않는_category_id_404(self) -> None:
+        """존재하지 않는 category_id는 404"""
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"category_id": 99999999})
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertIn("error_detail", response.data)
+        self.assertEqual(response.data["error_detail"], "조회 가능한 질문이 존재하지 않습니다.")
+
+    # ── 답변 상태 필터 ───────────────────────────────────────────────
+
+    def test_answer_status_answered_필터(self) -> None:
+        # question1에 답변 달기 (Answer 모델 직접 생성)
+        from django.apps import apps
+
+        from apps.qna.models.question_models import Question as Q
+
+        Answer = apps.get_model("qna", "Answer")
+        Answer.objects.create(
+            author=self.other_student,
+            question=self.question1,
+            content="답변입니다.",
+        )
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"answer_status": "answered"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        self.assertIn(self.question1.id, ids)
+        self.assertNotIn(self.question2.id, ids)
+
+    def test_answer_status_unanswered_필터(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"answer_status": "unanswered"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        for item in response.data["results"]:
+            self.assertEqual(item["answer_count"], 0)
+
+    def test_answer_status_잘못된_값_400(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"answer_status": "invalid"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    # ── 정렬 ─────────────────────────────────────────────────────────
+
+    def test_sort_latest_최신순(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"sort": "latest"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        # question3이 가장 나중에 생성됐으므로 첫 번째
+        self.assertEqual(ids[0], self.question3.id)
+
+    def test_sort_oldest_오래된순(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"sort": "oldest"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        # question1이 가장 먼저 생성됐으므로 첫 번째
+        self.assertEqual(ids[0], self.question1.id)
+
+    def test_sort_views_조회수순(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"sort": "views"})
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        ids = self._get_result_ids(response.data)
+        # view_count: question3=20, question1=10, question2=5
+        self.assertEqual(ids[0], self.question3.id)
+
+    def test_sort_잘못된_값_400(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"sort": "invalid"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    # ── 인증/권한 에러 케이스 ────────────────────────────────────────
+
+    def test_비로그인_목록_조회_401(self) -> None:
+        response = self.client.get(URL)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_general_권한_목록_조회_403(self) -> None:
+        self._force_login(self.general_user)
+
+        response = self.client.get(URL)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    # ── Query Param 유효성 ───────────────────────────────────────────
+
+    def test_page_문자열_400(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"page": "abc"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_category_id_문자열_400(self) -> None:
+        self._force_login(self.student_user)
+
+        response = self.client.get(URL, {"category_id": "abc"})
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)

--- a/apps/qna/views/question_views.py
+++ b/apps/qna/views/question_views.py
@@ -1,3 +1,4 @@
+import math
 from typing import Any, NoReturn, cast
 
 from rest_framework import status
@@ -7,14 +8,17 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsStudentUser
+from apps.qna.models import QuestionCategory
 from apps.qna.schemas.question_schemas import (
     question_create_schema,
+    question_list_schema,
 )
 from apps.qna.serializers.question_serializers import (
     QuestionCreateResponseSerializer,
     QuestionCreateSerializer,
+    QuestionListItemSerializer,
 )
-from apps.qna.services.question_services import QuestionService
+from apps.qna.services.question_services import QuestionListService, QuestionService
 from apps.users.models import User
 
 
@@ -53,4 +57,81 @@ class QuestionAPIView(APIView):
                 "question_id": question.id,
             },
             status=status.HTTP_201_CREATED,
+        )
+
+    # ── GET /api/v1/qna/questions ─────────────────────────────────────
+    @question_list_schema
+    def get(self, request: Request) -> Response:
+        try:
+            page = max(1, int(request.query_params.get("page", 1)))
+            page_size = max(1, min(100, int(request.query_params.get("page_size", 10))))
+        except ValueError:
+            return Response(
+                {"error_detail": "유효하지 않은 목록 조회 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        search_keyword = request.query_params.get("search_keyword") or None
+        answer_status = request.query_params.get("answer_status") or None
+        sort = request.query_params.get("sort", "latest")
+
+        raw_category_id = request.query_params.get("category_id")
+        category_id: int | None = None
+        if raw_category_id:
+            try:
+                category_id = int(raw_category_id)
+            except ValueError:
+                return Response(
+                    {"error_detail": "유효하지 않은 목록 조회 요청입니다."},
+                    status=status.HTTP_400_BAD_REQUEST,
+                )
+            if not QuestionCategory.objects.filter(id=category_id).exists():
+                return Response(
+                    {"error_detail": "조회 가능한 질문이 존재하지 않습니다."},
+                    status=status.HTTP_404_NOT_FOUND,
+                )
+
+        if answer_status and answer_status not in {"answered", "unanswered"}:
+            return Response(
+                {"error_detail": "유효하지 않은 목록 조회 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        if sort not in {"latest", "oldest", "views"}:
+            return Response(
+                {"error_detail": "유효하지 않은 목록 조회 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        questions, total_count = QuestionListService.get_question_list(
+            page=page,
+            page_size=page_size,
+            search_keyword=search_keyword,
+            category_id=category_id,
+            answer_status=answer_status,
+            sort=sort,
+        )
+
+        results = [QuestionListService.build_result(q) for q in questions]
+        serializer = QuestionListItemSerializer(results, many=True)
+
+        total_pages = math.ceil(total_count / page_size) if total_count else 1
+        base_url = request.build_absolute_uri(request.path)
+
+        def build_url(p: int) -> str | None:
+            if p < 1 or p > total_pages:
+                return None
+            params = request.query_params.dict()
+            params["page"] = str(p)
+            query_string = "&".join(f"{k}={v}" for k, v in params.items())
+            return f"{base_url}?{query_string}"
+
+        return Response(
+            {
+                "count": total_count,
+                "next": build_url(page + 1),
+                "previous": build_url(page - 1),
+                "results": serializer.data,
+            },
+            status=status.HTTP_200_OK,
         )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 질의 응답 목록 조회 API 구현

## 📄 상세 내용
- [ ] 질의응답 목록 조회 API 구현
- [ ] 테스트 코드 

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
