### PR TITLE
✨ feat: 휴대폰 번호 변경 기능 추가

### DIFF
--- a/apps/users/serializers/change_phone_serializer.py
+++ b/apps/users/serializers/change_phone_serializer.py
@@ -1,0 +1,10 @@
+from typing import Any
+
+from rest_framework import serializers
+
+
+class ChangePhoneSerializer(serializers.Serializer[Any]):
+    phone_verify_token = serializers.CharField(
+        required=True,
+        error_messages={"required": "이 필드는 필수 항목입니다."},
+    )

--- a/apps/users/services/auth_sms_service.py
+++ b/apps/users/services/auth_sms_service.py
@@ -34,7 +34,7 @@ class SmsVerificationService:
                 raise ValidationError("등록된 전화번호가 아닙니다.")
 
         elif purpose == SmsPurpose.PHONE_CHANGE:
-            if not User.objects.filter(phone_number=phone_number).exists():
+            if User.objects.filter(phone_number=phone_number).exists():
                 raise ValidationError("변경가능한 번호가 아닙니다")
 
         cache_key = f"sms_code_{phone_number}"

--- a/apps/users/services/change_phone_service.py
+++ b/apps/users/services/change_phone_service.py
@@ -1,0 +1,54 @@
+from typing import Any
+
+from django.core.cache import cache
+from django.db import transaction
+from rest_framework.exceptions import ValidationError
+
+from apps.users.models import User
+from apps.users.utils.purpose_enum import SmsPurpose
+from apps.users.utils.user_exceptions import ConflictError
+
+PHONE_CHANGE = SmsPurpose.PHONE_CHANGE.value
+
+
+def change_phone_service(validated_data: dict[str, Any], user: User) -> str:
+    """
+    sms 인증 토큰을 받아 redis cache에
+    저장된 phone_number, purpose를 꺼내서 용도 확인 후
+    DB에 동일한 번호가 없으면 기존 번호를 새 번호로 변경
+    """
+    sms_token = validated_data["phone_verify_token"]
+    sms_key = f"sms_verify_token_{sms_token}"
+
+    # 캐시에 저장된 용도, 전화번호 조회
+    sms_data = cache.get(sms_key)
+
+    # 토큰 유효성 확인
+    if not sms_data:
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+
+    if PHONE_CHANGE != sms_data.get("purpose"):
+        raise ValidationError("유효하지 않거나 만료된 인증 토큰입니다.")
+
+    new_phone_number: str = sms_data.get("phone_number")
+
+    # 현재 번호와 동일한지 확인
+    if user.phone_number == new_phone_number:
+        raise ValidationError("현재 휴대폰 번호와 동일합니다.")
+
+    with transaction.atomic():
+        # 변경 대상 유저 락
+        locked_user = User.objects.select_for_update().get(pk=user.pk)
+
+        # DB 중복 확인 (본인 번호 제외)
+        if User.objects.filter(phone_number=new_phone_number).exists():
+            raise ConflictError("이미 등록된 휴대폰 번호입니다.")
+
+        # 전화번호 변경
+        locked_user.phone_number = new_phone_number
+        locked_user.save(update_fields=["phone_number"])
+
+    # 사용한 토큰 즉시 삭제 (재사용 방지)
+    cache.delete(sms_key)
+
+    return new_phone_number

--- a/apps/users/tests/test_change_phone.py
+++ b/apps/users/tests/test_change_phone.py
@@ -1,0 +1,122 @@
+import uuid
+from typing import Optional
+
+from django.core.cache import cache
+from django.urls import reverse
+from rest_framework import status
+
+from apps.core.utils.isolated_cache_testcase import IsolatedRedisTestClient
+from apps.users.models import User
+from apps.users.utils.purpose_enum import SmsPurpose
+
+
+class ChangePhoneAPITestCase(IsolatedRedisTestClient):
+    # 테스트에 사용할 유저 정보
+    user: User
+    other_user: User
+    current_phone: str = "01011112222"
+    new_phone: str = "01033334444"
+    other_phone: str = "01055556666"
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        """테스트 전체에서 공통으로 사용할 유저 생성"""
+        cls.user = User.objects.create_user(
+            email="test@coding.com",
+            password="testPhone12!@",
+            name="테스터",
+            nickname="tester",
+            phone_number=cls.current_phone,
+        )
+        # 중복 확인 테스트용 다른 유저
+        cls.other_user = User.objects.create_user(
+            email="other@coding.com",
+            password="otherPhone12!@",
+            name="다른유저",
+            nickname="other",
+            phone_number=cls.other_phone,
+        )
+
+    def setUp(self) -> None:
+        super().setUp()
+        # 테스트에 사용할 API URL 및 토큰 설정
+        self.url: str = reverse("users:change-phone")
+        self.sms_token: str = f"token_{uuid.uuid4().hex}"
+        self.cache_key: str = f"sms_verify_token_{self.sms_token}"
+        # 기본 유효 페이로드
+        self.valid_payload = {"phone_verify_token": self.sms_token}
+        # 인증된 유저로 클라이언트 설정
+        self.client.force_authenticate(user=self.user)
+
+    def set_cache_data(
+        self,
+        phone_number: Optional[str] = None,
+        purpose: str = SmsPurpose.PHONE_CHANGE.value,
+    ) -> None:
+        """Redis 캐시에 인증 데이터를 주입"""
+        cache.set(
+            self.cache_key,
+            {"phone_number": phone_number or self.new_phone, "purpose": purpose},
+            timeout=300,
+        )
+
+    def test_change_phone_success(self) -> None:
+        """정상적인 토큰으로 휴대폰 번호 변경 성공 (200) 테스트"""
+        self.set_cache_data()
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "휴대폰 번호 변경에 성공하였습니다.")
+        self.assertEqual(response.data["phone_number"], self.new_phone)
+        # DB 반영 확인
+        self.user.refresh_from_db()
+        self.assertEqual(self.user.phone_number, self.new_phone)
+        # 사용된 Redis 토큰 삭제 확인
+        self.assertIsNone(cache.get(self.cache_key))
+
+    def test_change_phone_with_invalid_token_returns_400(self) -> None:
+        """존재하지 않거나 만료된 토큰 사용 시 400 반환 테스트"""
+        # 캐시 설정 없이 요청
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_change_phone_with_wrong_purpose_returns_400(self) -> None:
+        """번호 변경용이 아닌 다른 용도의 토큰 사용 시 400 반환 테스트"""
+        self.set_cache_data(purpose=SmsPurpose.SIGNUP.value)
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "유효하지 않거나 만료된 인증 토큰입니다.")
+
+    def test_change_phone_with_same_number_returns_400(self) -> None:
+        """현재 번호와 동일한 번호로 변경 시 400 반환 테스트"""
+        self.set_cache_data(phone_number=self.current_phone)
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.data["error_detail"][0], "현재 휴대폰 번호와 동일합니다.")
+
+    def test_change_phone_with_duplicated_number_returns_409(self) -> None:
+        """다른 유저가 사용 중인 번호로 변경 시 409 반환 테스트"""
+        self.set_cache_data(phone_number=self.other_phone)
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_409_CONFLICT)
+        self.assertEqual(response.data["error_detail"], "이미 등록된 휴대폰 번호입니다.")
+
+    def test_change_phone_missing_token_returns_400(self) -> None:
+        """필수 필드 누락 시 400 반환 테스트"""
+        response = self.client.patch(self.url, {}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_change_phone_unauthenticated_returns_401(self) -> None:
+        """비로그인 요청 시 401 반환 테스트"""
+        self.client.force_authenticate(user=None)
+        self.set_cache_data()
+        response = self.client.patch(self.url, self.valid_payload, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)

--- a/apps/users/urls/__init__.py
+++ b/apps/users/urls/__init__.py
@@ -14,4 +14,5 @@ urlpatterns = [
     path("", include("apps.users.urls.user_signup_url")),
     path("", include("apps.users.urls.user_login_url")),
     path("", include("apps.users.urls.find_password_url")),
+    path("", include("apps.users.urls.change_phone_url")),
 ]

--- a/apps/users/urls/change_phone_url.py
+++ b/apps/users/urls/change_phone_url.py
@@ -1,0 +1,7 @@
+from django.urls import path
+
+from apps.users.views.change_phone_view import ChangePhoneView
+
+urlpatterns = [
+    path("change-phone", ChangePhoneView.as_view(), name="change-phone"),
+]

--- a/apps/users/views/change_phone_view.py
+++ b/apps/users/views/change_phone_view.py
@@ -1,0 +1,48 @@
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import ValidationError
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.users.models import User
+from apps.users.serializers.change_phone_serializer import ChangePhoneSerializer
+from apps.users.services.change_phone_service import change_phone_service
+from apps.users.utils.user_exceptions import ConflictError
+
+
+class ChangePhoneView(APIView):
+    permission_classes = [IsAuthenticated]
+
+    @extend_schema(
+        tags=["accounts"],
+        summary="휴대폰 번호 변경 api",
+        description="sms 인증 후 발급받은 토큰을 활용하여 휴대폰 번호 변경",
+        request=ChangePhoneSerializer,
+        responses={
+            200: OpenApiResponse(description="휴대폰 번호 변경 성공"),
+            400: OpenApiResponse(description="유효성 검사 실패"),
+            401: OpenApiResponse(description="자격 인증 실패"),
+            409: OpenApiResponse(description="이미 등록된 휴대폰 번호"),
+        },
+    )
+    def patch(self, request: Request) -> Response:
+        serializer = ChangePhoneSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            user = request.user
+            assert isinstance(user, User)
+            new_phone_number = change_phone_service(serializer.validated_data, user)
+            return Response(
+                {
+                    "detail": "휴대폰 번호 변경에 성공하였습니다.",
+                    "phone_number": new_phone_number,
+                },
+                status=status.HTTP_200_OK,
+            )
+        except ConflictError as e:
+            return Response({"error_detail": str(e)}, status=status.HTTP_409_CONFLICT)
+        except ValidationError as e:
+            return Response({"error_detail": e.detail}, status=status.HTTP_400_BAD_REQUEST)


### PR DESCRIPTION
- SMS 인증 토큰으로 캐시에서 새 전화번호 조회
- 현재 번호와 동일한 번호 변경 및 타 유저 사용 중인 번호 변경 시 에러 반환

## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: SMS 인증 토큰을 활용한 휴대폰 번호 변경 기능 구현

## 📄 상세 내용
- [ ] SMS 인증 토큰으로 캐시에서 새 전화번호를 조회하여 번호 변경
- [ ] 현재 번호와 동일한 번호 / 타 유저 사용 중인 번호 변경 시도 예외 처리

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
