### PR TITLE
Feature/admin permission : 어드민 페이지 권한 변경 API

### DIFF
--- a/apps/users/serializers/admin_permission_serializer.py
+++ b/apps/users/serializers/admin_permission_serializer.py
@@ -1,30 +1,30 @@
+from typing import Any
+
 from rest_framework import serializers
 
-class AdminPermissionSerializer(serializers.Serializer):
-    ROLES = ['USER', 'STUDENT', 'ADMIN']
+
+class AdminPermissionSerializer(serializers.Serializer[Any]):
+    ROLES = ["USER", "STUDENT", "ADMIN", "TA", "OM", "LC"]
 
     role = serializers.ChoiceField(choices=ROLES)
     cohort_id = serializers.IntegerField(required=False, allow_null=True)
-    #리스트로 받아올때: ListField
-    #child: 리스트 안 원소 타입 지정
-    assigned_courses = serializers.ListField(
-        child=serializers.IntegerField(),
-        required=False
-    )
+    # 리스트로 받아올때: ListField
+    # child: 리스트 안 원소 타입 지정
+    assigned_courses = serializers.ListField(child=serializers.IntegerField(), required=False)
 
-    #validate_<field>()는 각 필드 초기 처리 단계에서 개별적으로 수행된다.
-    #반면 validate(attrs)는 모든 필드가 검증을 통과한 뒤 마지막에 실행된다.
-    def validate(self, attrs):
-        role = attrs.get('role')
-        cohort_id = attrs.get('role')
-        assigned_courses = attrs.get('assigned_courses')
+    # validate_<field>()는 각 필드 초기 처리 단계에서 개별적으로 수행된다.
+    # 반면 validate(attrs)는 모든 필드가 검증을 통과한 뒤 마지막에 실행된다.
+    def validate(self, attrs: dict[str, Any]) -> dict[str, Any]:
+        role = attrs.get("role")
+        cohort_id = attrs.get("cohort_id")
+        assigned_courses = attrs.get("assigned_courses")
 
-        #TA, STUDENT는 cohort_id 필수
-        if role in ['TA', "STUDENT"] and not cohort_id:
-                raise serializers.ValidationError({'cohort_id': F'{role}로 권한 변경 시 필수 필드입니다.'})
+        # TA, STUDENT는 cohort_id 필수
+        if role in ["TA", "STUDENT"] and not cohort_id:
+            raise serializers.ValidationError({"cohort_id": f"{role}로 권한 변경 시 필수 필드입니다."})
 
-        #OM, LC는 assigned_courses 필수
-        if role in ['OM', 'LC'] and not assigned_courses:
-                raise serializers.ValidationError({'assigned_courses': f'{role}로 권한 변경 시 필수 필드입니다.'})
+        # OM, LC는 assigned_courses 필수
+        if role in ["OM", "LC"] and not assigned_courses:
+            raise serializers.ValidationError({"assigned_courses": f"{role}로 권한 변경 시 필수 필드입니다."})
 
         return attrs

--- a/apps/users/serializers/admin_permission_serializer.py
+++ b/apps/users/serializers/admin_permission_serializer.py
@@ -1,0 +1,30 @@
+from rest_framework import serializers
+
+class AdminPermissionSerializer(serializers.Serializer):
+    ROLES = ['USER', 'STUDENT', 'ADMIN']
+
+    role = serializers.ChoiceField(choices=ROLES)
+    cohort_id = serializers.IntegerField(required=False, allow_null=True)
+    #리스트로 받아올때: ListField
+    #child: 리스트 안 원소 타입 지정
+    assigned_courses = serializers.ListField(
+        child=serializers.IntegerField(),
+        required=False
+    )
+
+    #validate_<field>()는 각 필드 초기 처리 단계에서 개별적으로 수행된다.
+    #반면 validate(attrs)는 모든 필드가 검증을 통과한 뒤 마지막에 실행된다.
+    def validate(self, attrs):
+        role = attrs.get('role')
+        cohort_id = attrs.get('role')
+        assigned_courses = attrs.get('assigned_courses')
+
+        #TA, STUDENT는 cohort_id 필수
+        if role in ['TA', "STUDENT"] and not cohort_id:
+                raise serializers.ValidationError({'cohort_id': F'{role}로 권한 변경 시 필수 필드입니다.'})
+
+        #OM, LC는 assigned_courses 필수
+        if role in ['OM', 'LC'] and not assigned_courses:
+                raise serializers.ValidationError({'assigned_courses': f'{role}로 권한 변경 시 필수 필드입니다.'})
+
+        return attrs

--- a/apps/users/services/admin_permission_service.py
+++ b/apps/users/services/admin_permission_service.py
@@ -1,41 +1,50 @@
+from typing import Any
+
 from django.db import transaction
 
-from apps.users.models import User, CohortStudents, OperationManagers, LearningCoachs, TrainigAssistants
+from apps.users.models import (
+    CohortStudents,
+    LearningCoachs,
+    OperationManagers,
+    TrainigAssistants,
+    User,
+)
 from apps.users.utils.user_exceptions import UserNotFoundError
 
-#기존 테이블 정보 삭제와 role 정보 추가를 하나의 작업 단위로 묶음
-@transaction.atomic
-def update_user_role(account_id, validated_data):
 
-    #유저 존재 여부(select_for_update: 수정하는동안 다른사람 못건그리게 잠금)
+# 기존 테이블 정보 삭제와 role 정보 추가를 하나의 작업 단위로 묶음
+@transaction.atomic
+def update_user_role(account_id: int, validated_data: dict[str, Any]) -> User:
+
+    # 유저 존재 여부(select_for_update: 수정하는동안 다른사람 못건그리게 잠금)
     try:
         user = User.objects.select_for_update().get(id=account_id)
     except User.DoesNotExist:
         raise UserNotFoundError()
 
-    role = validated_data['role']
+    role = validated_data["role"]
 
-    #기존 테이블 정보 삭제
-    tables_to_clear = [CohortStudents, OperationManagers, LearningCoachs, TrainigAssistants]
+    # 기존 테이블 정보 삭제
+    tables_to_clear: list[Any] = [CohortStudents, OperationManagers, LearningCoachs, TrainigAssistants]
     for table in tables_to_clear:
         table.objects.filter(user=user).delete()
 
-    #변경된 role 정보 추가
-    if role == 'STUDENT':
-        CohortStudents.objects.create(user=user, cohort_id=validated_data['cohort_id'])
+    # 변경된 role 정보 추가
+    if role == "STUDENT":
+        CohortStudents.objects.create(user=user, cohort_id=validated_data["cohort_id"])
 
-    elif role == 'TA':
-        TrainigAssistants.objects.create(user=user, cohort_id=validated_data['cohort_id'])
+    elif role == "TA":
+        TrainigAssistants.objects.create(user=user, cohort_id=validated_data["cohort_id"])
 
-    elif role == 'OM':
-        for course_id in validated_data['assigned_courses']:
+    elif role == "OM":
+        for course_id in validated_data["assigned_courses"]:
             OperationManagers.objects.create(user=user, course_id=course_id)
 
-    elif role == 'LC':
-        for course_id in validated_data['assigned_courses']:
+    elif role == "LC":
+        for course_id in validated_data["assigned_courses"]:
             LearningCoachs.objects.create(user=user, course_id=course_id)
 
-    #role 변경 로직
+    # role 변경 로직
     user.role = role
     user.save()
 

--- a/apps/users/services/admin_permission_service.py
+++ b/apps/users/services/admin_permission_service.py
@@ -1,0 +1,42 @@
+from django.db import transaction
+
+from apps.users.models import User, CohortStudents, OperationManagers, LearningCoachs, TrainigAssistants
+from apps.users.utils.user_exceptions import UserNotFoundError
+
+#기존 테이블 정보 삭제와 role 정보 추가를 하나의 작업 단위로 묶음
+@transaction.atomic
+def update_user_role(account_id, validated_data):
+
+    #유저 존재 여부(select_for_update: 수정하는동안 다른사람 못건그리게 잠금)
+    try:
+        user = User.objects.select_for_update().get(id=account_id)
+    except User.DoesNotExist:
+        raise UserNotFoundError()
+
+    role = validated_data['role']
+
+    #기존 테이블 정보 삭제
+    tables_to_clear = [CohortStudents, OperationManagers, LearningCoachs, TrainigAssistants]
+    for table in tables_to_clear:
+        table.objects.filter(user=user).delete()
+
+    #변경된 role 정보 추가
+    if role == 'STUDENT':
+        CohortStudents.objects.create(user=user, cohort_id=validated_data['cohort_id'])
+
+    elif role == 'TA':
+        TrainigAssistants.objects.create(user=user, cohort_id=validated_data['cohort_id'])
+
+    elif role == 'OM':
+        for course_id in validated_data['assigned_courses']:
+            OperationManagers.objects.create(user=user, course_id=course_id)
+
+    elif role == 'LC':
+        for course_id in validated_data['assigned_courses']:
+            LearningCoachs.objects.create(user=user, course_id=course_id)
+
+    #role 변경 로직
+    user.role = role
+    user.save()
+
+    return user

--- a/apps/users/tests/admin_permission_test.py
+++ b/apps/users/tests/admin_permission_test.py
@@ -1,0 +1,212 @@
+# apps/users/tests/test_admin_permission_view.py
+from datetime import date
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.courses.models.cohort import Cohort
+from apps.posts.models.course import Course
+from apps.users.models import (
+    CohortStudents,
+    LearningCoachs,
+    OperationManagers,
+    TrainigAssistants,
+    User,
+)
+
+
+class AdminPermissionViewTest(APITestCase):
+    admin_user: User
+    target_user: User
+    course: Course
+    cohort: Cohort
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        cls.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="Test1234!",
+            name="어드민",
+            nickname="어드민닉",
+            phone_number="01011112222",
+            role=User.Role.ADMIN,
+        )
+        cls.target_user = User.objects.create_user(
+            email="target@test.com",
+            password="Test1234!",
+            name="대상유저",
+            nickname="대상닉",
+            phone_number="01033334444",
+            role=User.Role.USER,
+        )
+        cls.course = Course.objects.create(name="백엔드", tag="BE")
+        cls.cohort = Cohort.objects.create(
+            course=cls.course,
+            number=1,
+            max_student=30,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 12, 31),
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+        self.client.force_authenticate(user=self.admin_user)
+        self.url = reverse(
+            "users:admin_permission",
+            kwargs={"account_id": self.target_user.id},
+        )
+
+    def test_change_role_to_user(self) -> None:
+        """USER로 권한 변경"""
+        response = self.client.patch(self.url, data={"role": "USER"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "USER")
+
+    def test_change_role_to_admin(self) -> None:
+        """ADMIN으로 권한 변경"""
+        response = self.client.patch(self.url, data={"role": "ADMIN"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "ADMIN")
+
+    def test_change_role_to_student(self) -> None:
+        """STUDENT로 권한 변경 - cohort_id 필요"""
+        response = self.client.patch(
+            self.url,
+            data={"role": "STUDENT", "cohort_id": self.cohort.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "STUDENT")
+        self.assertTrue(
+            CohortStudents.objects.filter(
+                user=self.target_user,
+                cohort=self.cohort,
+            ).exists()
+        )
+
+    def test_change_role_to_ta(self) -> None:
+        """TA로 권한 변경 - cohort_id 필요"""
+        response = self.client.patch(
+            self.url,
+            data={"role": "TA", "cohort_id": self.cohort.id},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "TA")
+        self.assertTrue(
+            TrainigAssistants.objects.filter(
+                user=self.target_user,
+                cohort=self.cohort,
+            ).exists()
+        )
+
+    def test_change_role_to_om(self) -> None:
+        """OM으로 권한 변경 - assigned_courses 필요"""
+        response = self.client.patch(
+            self.url,
+            data={"role": "OM", "assigned_courses": [self.course.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "OM")
+        self.assertTrue(
+            OperationManagers.objects.filter(
+                user=self.target_user,
+                course=self.course,
+            ).exists()
+        )
+
+    def test_change_role_to_lc(self) -> None:
+        """LC로 권한 변경 - assigned_courses 필요"""
+        response = self.client.patch(
+            self.url,
+            data={"role": "LC", "assigned_courses": [self.course.id]},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.target_user.refresh_from_db()
+        self.assertEqual(self.target_user.role, "LC")
+        self.assertTrue(
+            LearningCoachs.objects.filter(
+                user=self.target_user,
+                course=self.course,
+            ).exists()
+        )
+
+    def test_previous_role_data_cleared(self) -> None:
+        """역할 변경 시 기존 테이블 데이터 삭제"""
+        OperationManagers.objects.create(user=self.target_user, course=self.course)
+        self.target_user.role = "OM"
+        self.target_user.save()
+
+        response = self.client.patch(self.url, data={"role": "USER"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertFalse(
+            OperationManagers.objects.filter(user=self.target_user).exists()
+        )
+
+    def test_student_without_cohort_id(self) -> None:
+        """STUDENT 권한 변경 시 cohort_id 없으면 400"""
+        response = self.client.patch(self.url, data={"role": "STUDENT"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_om_without_assigned_courses(self) -> None:
+        """OM 권한 변경 시 assigned_courses 없으면 400"""
+        response = self.client.patch(self.url, data={"role": "OM"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertIn("error_detail", response.data)
+
+    def test_invalid_role(self) -> None:
+        """존재하지 않는 role - 400"""
+        response = self.client.patch(self.url, data={"role": "INVALID"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+
+    def test_user_not_found(self) -> None:
+        """존재하지 않는 유저 - 404"""
+        url = reverse("users:admin_permission", kwargs={"account_id": 99999})
+        response = self.client.patch(url, data={"role": "USER"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(
+            response.data["error_detail"],
+            "사용자 정보를 찾을 수 없습니다.",
+        )
+
+    def test_unauthenticated(self) -> None:
+        """비로그인 시 401"""
+        self.client.force_authenticate(user=None)
+        response = self.client.patch(self.url, data={"role": "USER"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_non_admin_forbidden(self) -> None:
+        """어드민 아닌 유저는 403"""
+        non_admin = User.objects.create_user(
+            email="user@test.com",
+            password="Test1234!",
+            name="일반유저",
+            nickname="일반닉",
+            phone_number="01055556666",
+            role=User.Role.USER,
+        )
+        self.client.force_authenticate(user=non_admin)
+        response = self.client.patch(self.url, data={"role": "USER"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)

--- a/apps/users/tests/admin_permission_test.py
+++ b/apps/users/tests/admin_permission_test.py
@@ -154,9 +154,7 @@ class AdminPermissionViewTest(APITestCase):
         response = self.client.patch(self.url, data={"role": "USER"}, format="json")
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        self.assertFalse(
-            OperationManagers.objects.filter(user=self.target_user).exists()
-        )
+        self.assertFalse(OperationManagers.objects.filter(user=self.target_user).exists())
 
     def test_student_without_cohort_id(self) -> None:
         """STUDENT 권한 변경 시 cohort_id 없으면 400"""

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -2,10 +2,12 @@ from django.urls import path
 
 from apps.users.views.admin_account_view import AdminAccountListView
 from apps.users.views.admin_detail_view import AdminAccountDetailView
+from apps.users.views.admin_permission_view import AdminPermissionView
 from apps.users.views.admin_update_view import AdminAccountUpdateView
 
 urlpatterns = [
     path("accounts", AdminAccountListView.as_view(), name="admin-account-list"),
     path("accounts/<int:account_id>", AdminAccountDetailView.as_view(), name="admin-account-detail"),
     path("accounts/<int:account_id>/update", AdminAccountUpdateView.as_view(), name="admin-account-update"),
+    path("accounts/<int:account_id>/role", AdminPermissionView.as_view(), name="admin_permission"),
 ]

--- a/apps/users/views/admin_permission_view.py
+++ b/apps/users/views/admin_permission_view.py
@@ -1,14 +1,21 @@
-from drf_spectacular.utils import extend_schema, OpenApiResponse
-from rest_framework.exceptions import NotAuthenticated, PermissionDenied, ValidationError
-from rest_framework.views import APIView
+from typing import Never
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import (
+    NotAuthenticated,
+    PermissionDenied,
+    ValidationError,
+)
 from rest_framework.request import Request
 from rest_framework.response import Response
-from rest_framework import status
+from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
-from apps.users.serializers.admin_permission_serializer import  AdminPermissionSerializer
-from apps.users.services .admin_permission_service import update_user_role
+from apps.users.serializers.admin_permission_serializer import AdminPermissionSerializer
+from apps.users.services.admin_permission_service import update_user_role
 from apps.users.utils.user_exceptions import UserNotFoundError
+
 
 class AdminPermissionView(APIView):
     permission_classes = [IsRoleAdminUser]
@@ -19,19 +26,19 @@ class AdminPermissionView(APIView):
         raise PermissionDenied("권한이 없습니다.")
 
     @extend_schema(
-        tags= ['acccounts'],
-        summary= '어드민 페이지 권한 변경 API',
-        description = '관리자 권한을 가진 유저는 특정 유저 권한 변경 가능',
-        request = AdminPermissionSerializer,
-        response ={
-            200: OpenApiResponse(description='권한이 변경되었습니다.'),
-            400: OpenApiResponse(description=''),
-            401: OpenApiResponse(description='자격 인증 데이터가 제공되지 않았습니다.'),
-            403: OpenApiResponse(description='권한이 없습니다.'),
-            404: OpenApiResponse(description='사용자 정보를 찾을 수 없습니다.'),
+        tags=["admin_accounts"],
+        summary="어드민 페이지 권한 변경 API",
+        description="관리자 권한을 가진 유저는 특정 유저 권한 변경 가능",
+        request=AdminPermissionSerializer,
+        responses={
+            200: OpenApiResponse(description="권한이 변경되었습니다."),
+            400: OpenApiResponse(description="role로 권한 변경 시 필수 필드입니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="권한이 없습니다."),
+            404: OpenApiResponse(description="사용자 정보를 찾을 수 없습니다."),
         },
     )
-    def patch(self, request: Request, account_id: int)-> Response:
+    def patch(self, request: Request, account_id: int) -> Response:
         serializer = AdminPermissionSerializer(data=request.data)
 
         if not serializer.is_valid():
@@ -39,6 +46,5 @@ class AdminPermissionView(APIView):
         try:
             update_user_role(account_id, serializer.validated_data)
         except UserNotFoundError as e:
-            return Response({'error_detail': str(e)}, status=status.HTTP_404_NOT_FOUND)
-        return Response({'detail': '권한이 변경되었습니다.'}, status=status.HTTP_200_OK)
-
+            return Response({"error_detail": str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response({"detail": "권한이 변경되었습니다."}, status=status.HTTP_200_OK)

--- a/apps/users/views/admin_permission_view.py
+++ b/apps/users/views/admin_permission_view.py
@@ -1,0 +1,44 @@
+from drf_spectacular.utils import extend_schema, OpenApiResponse
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied, ValidationError
+from rest_framework.views import APIView
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework import status
+
+from apps.core.utils.permissions import IsRoleAdminUser
+from apps.users.serializers.admin_permission_serializer import  AdminPermissionSerializer
+from apps.users.services .admin_permission_service import update_user_role
+from apps.users.utils.user_exceptions import UserNotFoundError
+
+class AdminPermissionView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
+        if not request.user.is_authenticated:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("권한이 없습니다.")
+
+    @extend_schema(
+        tags= ['acccounts'],
+        summary= '어드민 페이지 권한 변경 API',
+        description = '관리자 권한을 가진 유저는 특정 유저 권한 변경 가능',
+        request = AdminPermissionSerializer,
+        response ={
+            200: OpenApiResponse(description='권한이 변경되었습니다.'),
+            400: OpenApiResponse(description=''),
+            401: OpenApiResponse(description='자격 인증 데이터가 제공되지 않았습니다.'),
+            403: OpenApiResponse(description='권한이 없습니다.'),
+            404: OpenApiResponse(description='사용자 정보를 찾을 수 없습니다.'),
+        },
+    )
+    def patch(self, request: Request, account_id: int)-> Response:
+        serializer = AdminPermissionSerializer(data=request.data)
+
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+        try:
+            update_user_role(account_id, serializer.validated_data)
+        except UserNotFoundError as e:
+            return Response({'error_detail': str(e)}, status=status.HTTP_404_NOT_FOUND)
+        return Response({'detail': '권한이 변경되었습니다.'}, status=status.HTTP_200_OK)
+


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 권한 변경 API 구현

## 📄 상세 내용
- [x] AdminPermissionView 구현 
- [x] AdminPermissionSerializer 구현
- [x] update_user_role 서비스 함수 구현

## 📸 스크린샷 (선택)
<img width="475" height="209" alt="스크린샷 2026-05-08 오후 2 01 47" src="https://github.com/user-attachments/assets/d5e59346-9f7b-47b0-98ce-95abb8ffb507" />
<img width="419" height="198" alt="스크린샷 2026-05-08 오후 2 02 38" src="https://github.com/user-attachments/assets/98726259-a99a-4f4d-a58a-e529bd984d19" />

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).