### PR TITLE
feat: 관리자 수강생 등록 거절 API 구현

### DIFF
--- a/apps/users/serializers/admin_student_enrollment_reject_serializer.py
+++ b/apps/users/serializers/admin_student_enrollment_reject_serializer.py
@@ -1,0 +1,21 @@
+from __future__ import annotations
+
+from typing import Any
+
+from rest_framework import serializers
+
+
+class AdminStudentEnrollmentRejectRequestSerializer(serializers.Serializer[Any]):
+    enrollments = serializers.ListField(child=serializers.IntegerField(), required=True)
+
+
+class AdminStudentEnrollmentRejectResponseSerializer(serializers.Serializer[Any]):
+    detail = serializers.CharField(read_only=True)
+
+
+class AdminStudentEnrollmentErrorSerializer(serializers.Serializer[Any]):
+    error_detail = serializers.CharField(read_only=True)
+
+
+class AdminStudentEnrollmentValidationErrorSerializer(serializers.Serializer[Any]):
+    error_detail = serializers.DictField(child=serializers.ListField(child=serializers.CharField()), read_only=True)

--- a/apps/users/services/admin_student_enrollment_reject_service.py
+++ b/apps/users/services/admin_student_enrollment_reject_service.py
@@ -1,0 +1,13 @@
+from __future__ import annotations
+
+from django.db import transaction
+
+from apps.users.models import StudentEnrollmentRequests
+
+
+def reject_student_enrollments(enrollment_ids: list[int]) -> None:
+    with transaction.atomic():
+        StudentEnrollmentRequests.objects.filter(id__in=enrollment_ids).update(
+            status=StudentEnrollmentRequests.Status.REJECTED,
+            accepted_at=None,
+        )

--- a/apps/users/tests/test_admin_student_enrollment_reject.py
+++ b/apps/users/tests/test_admin_student_enrollment_reject.py
@@ -1,0 +1,108 @@
+from __future__ import annotations
+
+from datetime import timedelta
+from typing import Any
+
+from django.utils import timezone
+from rest_framework import status
+from rest_framework.response import Response
+from rest_framework.test import APIRequestFactory, APITestCase, force_authenticate
+
+from apps.courses.models.cohort import Cohort
+from apps.posts.models.course import Course
+from apps.users.models import StudentEnrollmentRequests, User
+from apps.users.views.admin_student_enrollment_reject_view import (
+    AdminStudentEnrollmentRejectView,
+)
+
+
+def create_user(
+    email: str = "test@oz.com",
+    password: str = "Test1234!@",
+    nickname: str = "테스터",
+    name: str = "홍길동",
+    phone_number: str = "01012345678",
+    role: str = User.Role.USER,
+) -> User:
+    return User.objects.create_user(
+        email=email,
+        password=password,
+        nickname=nickname,
+        name=name,
+        phone_number=phone_number,
+        role=role,
+    )
+
+
+def create_admin() -> User:
+    return create_user(
+        email="admin@oz.com",
+        nickname="관리자",
+        phone_number="01099998888",
+        role=User.Role.ADMIN,
+    )
+
+
+def create_cohort() -> Cohort:
+    course = Course.objects.create(name="초격차 백엔드 부트캠프", tag="BE")
+    return Cohort.objects.create(
+        course=course,
+        number=1,
+        max_student=30,
+        start_date=timezone.localdate(),
+        end_date=timezone.localdate() + timedelta(weeks=24),
+    )
+
+
+class AdminStudentEnrollmentRejectViewTest(APITestCase):
+    """POST /api/v1/admin/student-enrollments/reject 수강생 등록 요청 거절"""
+
+    def setUp(self) -> None:
+        self.admin = create_admin()
+        self.factory = APIRequestFactory()
+        self.view = AdminStudentEnrollmentRejectView.as_view()
+        self.url = "/api/v1/admin/student-enrollments/reject"
+        self.cohort = create_cohort()
+        self.user = create_user(email="student@oz.com", nickname="수강생", phone_number="01022223333")
+        self.enrollment = StudentEnrollmentRequests.objects.create(
+            user=self.user,
+            cohort=self.cohort,
+            status=StudentEnrollmentRequests.Status.PENDING,
+        )
+
+    def post_reject(self, data: dict[str, Any], user: User | None = None) -> Response:
+        request = self.factory.post(self.url, data=data, format="json")
+        if user is not None:
+            force_authenticate(request, user=user)
+        return self.view(request)
+
+    def test_admin_can_reject_student_enrollments(self) -> None:
+        response = self.post_reject({"enrollments": [self.enrollment.id]}, self.admin)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.data["detail"], "수강생 등록 신청들에 대한 거절 요청이 처리되었습니다.")
+        self.enrollment.refresh_from_db()
+        self.assertEqual(self.enrollment.status, StudentEnrollmentRequests.Status.REJECTED)
+
+    def test_missing_enrollments_returns_400_with_exact_message(self) -> None:
+        response = self.post_reject({}, self.admin)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(
+            response.data,
+            {"error_detail": {"enrollments": ["이 필드는 필수 항목입니다."]}},
+        )
+
+    def test_without_token_returns_401_with_exact_message(self) -> None:
+        response = self.post_reject({"enrollments": [self.enrollment.id]})
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+        self.assertEqual(response.data, {"error_detail": "자격 인증 데이터가 제공되지 않았습니다."})
+
+    def test_non_admin_returns_403_with_exact_message(self) -> None:
+        normal_user = create_user(email="normal@oz.com", nickname="일반유저", phone_number="01033334444")
+
+        response = self.post_reject({"enrollments": [self.enrollment.id]}, normal_user)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+        self.assertEqual(response.data, {"error_detail": "권한이 없습니다."})

--- a/apps/users/views/admin_student_enrollment_reject_view.py
+++ b/apps/users/views/admin_student_enrollment_reject_view.py
@@ -1,0 +1,62 @@
+from __future__ import annotations
+
+from typing import NoReturn
+
+from drf_spectacular.utils import OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.permissions import IsRoleAdminUser
+from apps.users.serializers.admin_student_enrollment_reject_serializer import (
+    AdminStudentEnrollmentErrorSerializer,
+    AdminStudentEnrollmentRejectRequestSerializer,
+    AdminStudentEnrollmentRejectResponseSerializer,
+    AdminStudentEnrollmentValidationErrorSerializer,
+)
+from apps.users.services.admin_student_enrollment_reject_service import (
+    reject_student_enrollments,
+)
+
+
+class AdminStudentEnrollmentRejectView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        if not request.user.is_authenticated:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("권한이 없습니다.")
+
+    @extend_schema(
+        tags=["admin_students"],
+        summary="어드민 수강생 등록 요청 거절",
+        description="어드민이 수강생 등록 신청들에 대한 거절 요청을 처리합니다.",
+        request=AdminStudentEnrollmentRejectRequestSerializer,
+        responses={
+            200: AdminStudentEnrollmentRejectResponseSerializer,
+            400: OpenApiResponse(
+                description="잘못된 요청",
+                response=AdminStudentEnrollmentValidationErrorSerializer,
+            ),
+            401: OpenApiResponse(
+                description="인증 실패",
+                response=AdminStudentEnrollmentErrorSerializer,
+            ),
+            403: OpenApiResponse(
+                description="권한 없음",
+                response=AdminStudentEnrollmentErrorSerializer,
+            ),
+        },
+    )
+    def post(self, request: Request) -> Response:
+        serializer = AdminStudentEnrollmentRejectRequestSerializer(data=request.data)
+        if not serializer.is_valid():
+            return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+
+        reject_student_enrollments(serializer.validated_data["enrollments"])
+        return Response(
+            {"detail": "수강생 등록 신청들에 대한 거절 요청이 처리되었습니다."},
+            status=status.HTTP_200_OK,
+        )


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #이슈번호
- 작업 요약: 어드민 페이지 수강생 등록 요청 거절 API를 구현했습니다.

## 📄 상세 내용
- [x] `POST /api/v1/admin/student-enrollments/reject` 요청 처리를 위한 View를 구현했습니다.
- [x] `enrollments` 요청 필드 검증용 Serializer를 추가했습니다.
- [x] 전달받은 수강생 등록 요청 ID 목록의 상태를 `StudentEnrollmentRequests.Status.REJECTED`로 변경하는 Service를 추가했습니다.
- [x] 200, 400, 401, 403 응답 형식과 메시지가 API 명세서와 일치하도록 처리했습니다.
- [x] 거절 API 전용 파일임을 명확히 하기 위해 파일명에 `_reject`를 붙여 분리했습니다.

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항
- API 명세서 37번: 어드민 페이지 수강생 등록 요청 거절 API 작업입니다.
- URL 연결은 별도 PR에서 처리하기로 하여 `admin_urls.py`는 이번 PR에 포함하지 않았습니다.
- 상태값은 하드코딩하지 않고 `StudentEnrollmentRequests.Status.REJECTED` 모델 enum을 사용했습니다.
- 현재 PR 변경량은 4개 파일, 215 lines입니다.

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).