### PR TITLE
Feature/admin permission : 어드민 페이지 수강생 목록 조회 API 구현

### DIFF
--- a/apps/users/serializers/admin_student_list_serializer.py
+++ b/apps/users/serializers/admin_student_list_serializer.py
@@ -1,0 +1,89 @@
+from typing import Any
+
+from rest_framework import serializers
+
+from apps.users.models import User, Withdrawal
+
+
+# cohort
+class CohortInfoSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    number = serializers.IntegerField()
+
+
+# course
+class CourseInfoSerializer(serializers.Serializer[Any]):
+    id = serializers.IntegerField()
+    name = serializers.CharField()
+    tag = serializers.CharField()
+
+
+# 현재 진행중인 기수 + 과정 묶어서 직렬화
+class InProgressCourseSerializer(serializers.Serializer[Any]):
+    cohort = CohortInfoSerializer()
+    course = CourseInfoSerializer()
+
+
+# 수강생 목록 메인 시리얼라이저
+class AdminStudentListSerializer(serializers.ModelSerializer[User]):
+    status = serializers.SerializerMethodField()
+    in_progress_course = serializers.SerializerMethodField()
+
+    class Meta:
+        model = User
+        fields = [
+            "id",
+            "email",
+            "nickname",
+            "name",
+            "phone_number",
+            "birthday",
+            "status",
+            "role",
+            "in_progress_course",
+            "created_at",
+        ]
+        read_only_fields = fields
+
+    # SerializerMethodField는 get_<필드명> 메서드를 자동으로 찾아 호출
+    def get_in_progress_course(self, obj: User) -> dict[str, Any] | None:
+        # __ -> 경로 cohort__status = CohortStudents -> cohort -> status
+        cohort_student = (
+            obj.cohort_students.select_related("cohort__course").filter(cohort__status="IN_PROGRESS").first()
+        )
+
+        if cohort_student is None:
+            return None
+
+        # mypy None 체크 요구(cohort 필드가 nullable)
+        cohort = cohort_student.cohort
+        if cohort is None:
+            return None
+
+        course = cohort.course
+        if course is None:
+            return None
+
+        return InProgressCourseSerializer(
+            {
+                "cohort": {
+                    "id": cohort.id,
+                    "number": cohort.number,
+                },
+                "course": {
+                    "id": cohort.course.id,
+                    "name": cohort.course.name,
+                    "tag": cohort.course.tag,
+                },
+            }
+        ).data  # json 변환 가능한 딕셔너리 반환
+
+    def get_status(self, obj: User) -> str:
+        try:
+            obj.withdrawal  # withdrawal 테이블에 레코드 있으면 "WITHDREW"반환
+            return "WITHDREW"
+        except Withdrawal.DoesNotExist:
+            pass
+        if obj.is_active:
+            return "ACTIVATED"
+        return "DEACTIVATED"

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -12,6 +12,7 @@ from apps.users.utils.user_exceptions import DuplicateNicknameError
 class UserInfoSerializer(serializers.ModelSerializer[User]):
     # 수강생인 경우 보여줄 추가 필드
     cohort_id = serializers.SerializerMethodField()
+    position = serializers.SerializerMethodField()
 
     class Meta:
         model = User
@@ -26,6 +27,7 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "profile_img_url",
             "cohort_id",
             "role",
+            'position',
             "created_at",
         ]
         read_only_fields = fields
@@ -36,6 +38,18 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
         if cohort_student is None or cohort_student.cohort is None:
             return None
         return cohort_student.cohort.id
+
+    def get_position(self, obj: User)-> str | None:
+        if obj.training_assistants.exists():
+            return 'TA'
+        if obj.operation_managers.exists():
+            return 'OM'
+        if obj.learning_coachs.exists():
+            return 'LC'
+        if obj.cohort_students.exists():
+            return 'ENROLLED'
+        return None
+
 
 
 # 내 정보 수정

--- a/apps/users/serializers/user_info_serializer.py
+++ b/apps/users/serializers/user_info_serializer.py
@@ -27,7 +27,7 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             "profile_img_url",
             "cohort_id",
             "role",
-            'position',
+            "position",
             "created_at",
         ]
         read_only_fields = fields
@@ -39,17 +39,16 @@ class UserInfoSerializer(serializers.ModelSerializer[User]):
             return None
         return cohort_student.cohort.id
 
-    def get_position(self, obj: User)-> str | None:
+    def get_position(self, obj: User) -> str | None:
         if obj.training_assistants.exists():
-            return 'TA'
+            return "TA"
         if obj.operation_managers.exists():
-            return 'OM'
+            return "OM"
         if obj.learning_coachs.exists():
-            return 'LC'
+            return "LC"
         if obj.cohort_students.exists():
-            return 'ENROLLED'
+            return "ENROLLED"
         return None
-
 
 
 # 내 정보 수정

--- a/apps/users/services/admin_atudent_list_service.py
+++ b/apps/users/services/admin_atudent_list_service.py
@@ -1,0 +1,43 @@
+from django.db.models import Q, QuerySet
+from rest_framework.request import Request
+
+from apps.users.models import User
+from apps.users.utils.pagination import RequestPagination
+
+
+def get_student_list(request: Request) -> tuple[list[User], RequestPagination]:
+    queryset = User.objects.prefetch_related("cohort_students__cohort__course", "withdrawal").order_by("id")
+
+    # 검색 기능(이메일, 이름, 닉네임, 휴대폰번호)
+    search = request.query_params.get("search")
+    if search:
+        queryset = queryset.filter(
+            Q(email__icontains=search)
+            | Q(name__icontains=search)
+            | Q(nickname__icontains=search)
+            | Q(phone_number__icontains=search)
+        )
+
+    # 과정별 필터링
+    course_id = request.query_params.get("course_id")
+    if course_id:
+        queryset = queryset.filter(cohort_students__cohort__course_id=int(course_id)).distinct()
+
+    # 기수별 필터링
+    cohort_id = request.query_params.get("cohort_id")
+    if cohort_id:
+        queryset = queryset.filter(cohort_students__cohort_id=int(cohort_id)).distinct()
+
+    # 상태 표시
+    status = request.query_params.get("status")
+    if status == "ACTIVATED":
+        queryset = queryset.filter(is_active=True, withdrawal__isnull=True)
+    elif status == "DEACTIVATED":
+        queryset = queryset.filter(is_active=False, withdrawal__isnull=True)
+    elif status == "WITHDREW":
+        queryset = queryset.filter(withdrawal__isnull=False)
+
+    # 페이지네이션
+    paginator = RequestPagination()
+    page = paginator.paginate_queryset(queryset, request)
+    return page, paginator

--- a/apps/users/services/admin_student_list_service.py
+++ b/apps/users/services/admin_student_list_service.py
@@ -1,11 +1,17 @@
 from django.db.models import Q, QuerySet
+from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 
 from apps.users.models import User
-from apps.users.utils.pagination import RequestPagination
 
 
-def get_student_list(request: Request) -> tuple[list[User], RequestPagination]:
+class Pagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+def get_student_list(request: Request) -> tuple[list[User], None, Pagination]:
     queryset = User.objects.prefetch_related("cohort_students__cohort__course", "withdrawal").order_by("id")
 
     # 검색 기능(이메일, 이름, 닉네임, 휴대폰번호)
@@ -38,6 +44,6 @@ def get_student_list(request: Request) -> tuple[list[User], RequestPagination]:
         queryset = queryset.filter(withdrawal__isnull=False)
 
     # 페이지네이션
-    paginator = RequestPagination()
+    paginator = Pagination()
     page = paginator.paginate_queryset(queryset, request)
     return page, paginator

--- a/apps/users/services/admin_student_list_service.py
+++ b/apps/users/services/admin_student_list_service.py
@@ -1,4 +1,4 @@
-from django.db.models import Q, QuerySet
+from django.db.models import Q
 from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 
@@ -11,7 +11,7 @@ class Pagination(PageNumberPagination):
     max_page_size = 100
 
 
-def get_student_list(request: Request) -> tuple[list[User], None, Pagination]:
+def get_student_list(request: Request) -> tuple[list[User] | None, Pagination]:
     queryset = User.objects.prefetch_related("cohort_students__cohort__course", "withdrawal").order_by("id")
 
     # 검색 기능(이메일, 이름, 닉네임, 휴대폰번호)

--- a/apps/users/tests/admin_student_list_test.py
+++ b/apps/users/tests/admin_student_list_test.py
@@ -10,7 +10,6 @@ from apps.users.models import CohortStudents, User, Withdrawal
 
 
 class AdminStudentListViewTest(APITestCase):
-    # 클래스 레벨 타입 어노테이션 (mypy 요구)
     admin: User
     student_active: User
     student_withdrew: User
@@ -23,7 +22,6 @@ class AdminStudentListViewTest(APITestCase):
 
     @classmethod
     def setUpTestData(cls) -> None:
-        # 1. 관리자
         cls.admin = User.objects.create_user(
             email="admin@test.com",
             password="testpass1234",
@@ -33,7 +31,6 @@ class AdminStudentListViewTest(APITestCase):
             role="ADMIN",
         )
 
-        # 2. 수강생들
         cls.student_active = User.objects.create_user(
             email="student1@test.com",
             password="testpass1234",
@@ -61,7 +58,6 @@ class AdminStudentListViewTest(APITestCase):
             is_active=False,
         )
 
-        # 3. 코스 + 기수
         cls.course1 = Course.objects.create(name="백엔드 부트캠프", tag="BE1")
         cls.course2 = Course.objects.create(name="프론트엔드 부트캠프", tag="FE1")
 
@@ -82,11 +78,9 @@ class AdminStudentListViewTest(APITestCase):
             status="PREPARING",
         )
 
-        # 4. 수강생-기수 연결
         CohortStudents.objects.create(user=cls.student_active, cohort=cls.cohort1_in_progress)
         CohortStudents.objects.create(user=cls.student_withdrew, cohort=cls.cohort2_preparing)
 
-        # 5. 탈퇴 레코드
         Withdrawal.objects.create(
             user=cls.student_withdrew,
             reason="OTHER",
@@ -188,7 +182,6 @@ class AdminStudentListViewTest(APITestCase):
     def test_in_progress_course_진행중기수없으면_None(self) -> None:
         self.client.force_authenticate(user=self.admin)
         response = self.client.get(self.url)
-        # student_withdrew는 PREPARING 기수에만 속함
         target = next(u for u in response.data["results"] if u["id"] == self.student_withdrew.id)
         self.assertIsNone(target["in_progress_course"])
 
@@ -246,7 +239,7 @@ class AdminStudentListViewTest(APITestCase):
         response = self.client.get(self.url, {"page_size": 2})
         self.assertEqual(len(response.data["results"]), 2)
 
-    def test_페이지네이션_유효하지않은_페이지_400(self) -> None:
+    def test_페이지네이션_유효하지않은_페이지_404(self) -> None:
         self.client.force_authenticate(user=self.admin)
         response = self.client.get(self.url, {"page": 9999})
-        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)

--- a/apps/users/tests/admin_student_list_test.py
+++ b/apps/users/tests/admin_student_list_test.py
@@ -1,0 +1,244 @@
+from datetime import date
+
+from django.urls import reverse
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.courses.models import Cohort
+from apps.posts.models.course import Course
+from apps.users.models import CohortStudents, User, Withdrawal
+
+
+class AdminStudentListViewTest(APITestCase):
+    # 클래스 레벨 타입 어노테이션 (mypy 요구)
+    admin: User
+    student_active: User
+    student_withdrew: User
+    student_deactivated: User
+    course1: Course
+    course2: Course
+    cohort1_in_progress: Cohort
+    cohort2_preparing: Cohort
+    url: str
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # 1. 관리자
+        cls.admin = User.objects.create_user(
+            email="admin@test.com",
+            password="testpass1234",
+            name="관리자",
+            nickname="admin",
+            phone_number="01000000000",
+            role="ADMIN",
+        )
+
+        # 2. 수강생들
+        cls.student_active = User.objects.create_user(
+            email="student1@test.com",
+            password="testpass1234",
+            name="김수강",
+            nickname="student1",
+            phone_number="01011111111",
+            birthday=date(2000, 1, 1),
+            role="STUDENT",
+        )
+        cls.student_withdrew = User.objects.create_user(
+            email="student2@test.com",
+            password="testpass1234",
+            name="이탈퇴",
+            nickname="student2",
+            phone_number="01022222222",
+            role="STUDENT",
+        )
+        cls.student_deactivated = User.objects.create_user(
+            email="student3@test.com",
+            password="testpass1234",
+            name="박비활성",
+            nickname="student3",
+            phone_number="01033333333",
+            role="STUDENT",
+            is_active=False,
+        )
+
+        # 3. 코스 + 기수
+        cls.course1 = Course.objects.create(name="백엔드 부트캠프", tag="BE1")
+        cls.course2 = Course.objects.create(name="프론트엔드 부트캠프", tag="FE1")
+
+        cls.cohort1_in_progress = Cohort.objects.create(
+            course=cls.course1,
+            number=1,
+            max_student=30,
+            start_date=date(2024, 1, 1),
+            end_date=date(2024, 6, 30),
+            status="IN_PROGRESS",
+        )
+        cls.cohort2_preparing = Cohort.objects.create(
+            course=cls.course2,
+            number=1,
+            max_student=30,
+            start_date=date(2025, 1, 1),
+            end_date=date(2025, 6, 30),
+            status="PREPARING",
+        )
+
+        # 4. 수강생-기수 연결
+        CohortStudents.objects.create(user=cls.student_active, cohort=cls.cohort1_in_progress)
+        CohortStudents.objects.create(user=cls.student_withdrew, cohort=cls.cohort2_preparing)
+
+        # 5. 탈퇴 레코드
+        Withdrawal.objects.create(
+            user=cls.student_withdrew,
+            reason="OTHER",
+            due_date=date(2024, 12, 31),
+        )
+
+        cls.url = reverse("admin-students-list")
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # ===== 권한 테스트 =====
+
+    def test_비인증_요청_401(self) -> None:
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def test_일반유저_요청_403(self) -> None:
+        normal_user = User.objects.create_user(
+            email="user@test.com",
+            password="testpass1234",
+            name="일반",
+            nickname="normal",
+            phone_number="01099999999",
+            role="USER",
+        )
+        self.client.force_authenticate(user=normal_user)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_수강생_요청_403(self) -> None:
+        self.client.force_authenticate(user=self.student_active)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+    def test_관리자_요청_200(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+    # ===== 응답 구조 테스트 =====
+
+    def test_응답_페이지네이션_구조(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        self.assertIn("count", response.data)
+        self.assertIn("next", response.data)
+        self.assertIn("previous", response.data)
+        self.assertIn("results", response.data)
+
+    def test_응답_필드_구조(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        first_user = response.data["results"][0]
+        expected_fields = {
+            "id", "email", "nickname", "name", "phone_number",
+            "birthday", "status", "role", "in_progress_course", "created_at",
+        }
+        self.assertEqual(set(first_user.keys()), expected_fields)
+
+    # ===== status 필드 테스트 =====
+
+    def test_status_탈퇴자는_WITHDREW(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        target = next(u for u in response.data["results"] if u["id"] == self.student_withdrew.id)
+        self.assertEqual(target["status"], "WITHDREW")
+
+    def test_status_활성유저는_ACTIVATED(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        target = next(u for u in response.data["results"] if u["id"] == self.student_active.id)
+        self.assertEqual(target["status"], "ACTIVATED")
+
+    def test_status_비활성유저는_DEACTIVATED(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        target = next(u for u in response.data["results"] if u["id"] == self.student_deactivated.id)
+        self.assertEqual(target["status"], "DEACTIVATED")
+
+    # ===== in_progress_course 필드 테스트 =====
+
+    def test_in_progress_course_진행중기수있으면_데이터반환(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        target = next(u for u in response.data["results"] if u["id"] == self.student_active.id)
+        self.assertIsNotNone(target["in_progress_course"])
+        self.assertEqual(target["in_progress_course"]["cohort"]["id"], self.cohort1_in_progress.id)
+        self.assertEqual(target["in_progress_course"]["course"]["id"], self.course1.id)
+
+    def test_in_progress_course_진행중기수없으면_None(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url)
+        # student_withdrew는 PREPARING 기수에만 속함
+        target = next(u for u in response.data["results"] if u["id"] == self.student_withdrew.id)
+        self.assertIsNone(target["in_progress_course"])
+
+    # ===== 검색 기능 테스트 =====
+
+    def test_검색_이메일(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search": "student1@test.com"})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertIn(self.student_active.id, ids)
+        self.assertNotIn(self.student_withdrew.id, ids)
+
+    def test_검색_이름(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search": "김수강"})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertEqual(ids, [self.student_active.id])
+
+    def test_검색_닉네임(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search": "student2"})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertEqual(ids, [self.student_withdrew.id])
+
+    def test_검색_휴대폰번호(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search": "01033333333"})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertEqual(ids, [self.student_deactivated.id])
+
+    def test_검색_결과없음(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"search": "존재하지않는검색어"})
+        self.assertEqual(response.data["count"], 0)
+
+    # ===== 필터링 테스트 =====
+
+    def test_필터_course_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"course_id": self.course1.id})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertIn(self.student_active.id, ids)
+        self.assertNotIn(self.student_withdrew.id, ids)
+
+    def test_필터_cohort_id(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"cohort_id": self.cohort1_in_progress.id})
+        ids = [u["id"] for u in response.data["results"]]
+        self.assertEqual(ids, [self.student_active.id])
+
+    # ===== 페이지네이션 테스트 =====
+
+    def test_페이지네이션_page_size(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"page_size": 2})
+        self.assertEqual(len(response.data["results"]), 2)
+
+    def test_페이지네이션_유효하지않은_페이지_400(self) -> None:
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(self.url, {"page": 9999})
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)

--- a/apps/users/tests/admin_student_list_test.py
+++ b/apps/users/tests/admin_student_list_test.py
@@ -142,8 +142,16 @@ class AdminStudentListViewTest(APITestCase):
         response = self.client.get(self.url)
         first_user = response.data["results"][0]
         expected_fields = {
-            "id", "email", "nickname", "name", "phone_number",
-            "birthday", "status", "role", "in_progress_course", "created_at",
+            "id",
+            "email",
+            "nickname",
+            "name",
+            "phone_number",
+            "birthday",
+            "status",
+            "role",
+            "in_progress_course",
+            "created_at",
         }
         self.assertEqual(set(first_user.keys()), expected_fields)
 

--- a/apps/users/tests/admin_student_list_test.py
+++ b/apps/users/tests/admin_student_list_test.py
@@ -4,8 +4,8 @@ from django.urls import reverse
 from rest_framework import status
 from rest_framework.test import APIClient, APITestCase
 
-from apps.courses.models import Cohort
-from apps.posts.models.course import Course
+from apps.courses.models.cohort import Cohort
+from apps.courses.models.course import Course
 from apps.users.models import CohortStudents, User, Withdrawal
 
 

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -11,6 +11,7 @@ from apps.users.views.admin_withdrawal_view import (
     AdminWithdrawalListView,
 )
 from apps.users.views.enrollment_accept_view import AdminStudentEnrollmentAcceptView
+from apps.users.views.admin_student_list_view import AdminStudentListView
 
 urlpatterns = [
     path("accounts", AdminAccountListView.as_view(), name="admin-account-list"),
@@ -22,4 +23,6 @@ urlpatterns = [
     path("withdrawals", AdminWithdrawalListView.as_view(), name="admin-withdrawal-list"),
     path("student-enrollments", AdminEnrollmentRequestListView.as_view(), name="student-enrollment-list"),
     path("withdrawals/<int:withdrawal_id>", AdminWithdrawalDetailView.as_view(), name="admin-withdrawal-detail"),
+    path("students", AdminStudentListView.as_view(), name="admin-students-list"),
+
 ]

--- a/apps/users/urls/admin_urls.py
+++ b/apps/users/urls/admin_urls.py
@@ -6,12 +6,12 @@ from apps.users.views.admin_permission_view import AdminPermissionView
 from apps.users.views.admin_student_enrollment_view import (
     AdminEnrollmentRequestListView,
 )
+from apps.users.views.admin_student_list_view import AdminStudentListView
 from apps.users.views.admin_withdrawal_view import (
     AdminWithdrawalDetailView,
     AdminWithdrawalListView,
 )
 from apps.users.views.enrollment_accept_view import AdminStudentEnrollmentAcceptView
-from apps.users.views.admin_student_list_view import AdminStudentListView
 
 urlpatterns = [
     path("accounts", AdminAccountListView.as_view(), name="admin-account-list"),
@@ -24,5 +24,4 @@ urlpatterns = [
     path("student-enrollments", AdminEnrollmentRequestListView.as_view(), name="student-enrollment-list"),
     path("withdrawals/<int:withdrawal_id>", AdminWithdrawalDetailView.as_view(), name="admin-withdrawal-detail"),
     path("students", AdminStudentListView.as_view(), name="admin-students-list"),
-
 ]

--- a/apps/users/views/admin_student_list_view.py
+++ b/apps/users/views/admin_student_list_view.py
@@ -11,7 +11,7 @@ from apps.core.utils.permissions import IsRoleAdminUser
 from apps.users.serializers.admin_student_list_serializer import (
     AdminStudentListSerializer,
 )
-from apps.users.services.admin_atudent_list_service import get_student_list
+from apps.users.services.admin_student_list_service import get_student_list
 
 
 class AdminStudentListView(APIView):

--- a/apps/users/views/admin_student_list_view.py
+++ b/apps/users/views/admin_student_list_view.py
@@ -1,0 +1,81 @@
+from typing import Never
+
+from django.db.models import Q
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
+from rest_framework.exceptions import NotAuthenticated, PermissionDenied
+from rest_framework.pagination import PageNumberPagination
+from rest_framework.request import Request
+from rest_framework.response import Response
+from rest_framework.views import APIView
+
+from apps.core.utils.permissions import IsRoleAdminUser
+from apps.users.models import User
+from apps.users.serializers.admin_student_list_serializer import (
+    AdminStudentListSerializer,
+)
+
+
+# 페이지네이션
+class Pagination(PageNumberPagination):
+    page_size = 10
+    page_size_query_param = "page_size"
+    max_page_size = 100
+
+
+class AdminStudentListView(APIView):
+    permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> Never:
+        if not request.user.is_authenticated:
+            raise NotAuthenticated("자격 인증 데이터가 제공되지 않았습니다.")
+        raise PermissionDenied("권한이 없습니다.")
+
+    @extend_schema(
+        tags=["admin_accounts"],
+        summary="어드민 페이지 수강생 목록 조회 API",
+        description="관리자 권한을 가진 유저는 어드민 페이지 회원관리메뉴에서 등록된 수강생 목록 조회 가능",
+        parameters=[
+            OpenApiParameter(name="page", type=int, required=False),
+            OpenApiParameter(name="page_size", type=int, required=False),
+            OpenApiParameter(name="search", type=str, required=False),
+        ],
+        responses={
+            200: AdminStudentListSerializer(many=True),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
+            403: OpenApiResponse(description="권한이 없습니다."),
+        },
+    )
+    def get(self, request: Request) -> Response:
+        queryset = User.objects.prefetch_related("cohort_students__cohort__course", "withdrawal").order_by("id")
+
+        # 검색 기능(이메일, 이름, 닉네임, 휴대폰번호)
+        search = request.query_params.get("search")
+        if search:
+            queryset = queryset.filter(
+                Q(email__icontains=search)
+                | Q(name__icontains=search)
+                | Q(nickname__icontains=search)
+                | Q(phone_number__icontains=search)
+            )
+
+        # 과정별 필터링
+        course_id = request.query_params.get("course_id")
+        if course_id:
+            queryset = queryset.filter(cohort_students__cohort__course_id=int(course_id)).distinct()
+
+        # 기수별 필터링
+        cohort_id = request.query_params.get("cohort_id")
+        if cohort_id:
+            queryset = queryset.filter(cohort_students__cohort_id=int(cohort_id)).distinct()
+
+        # 페이지네이션
+        paginator = Pagination()
+
+        try:
+            page = paginator.paginate_queryset(queryset, request)
+        except Exception:
+            return Response({"detail": "유효하지 않은 페이지입니다."}, status=status.HTTP_400_BAD_REQUEST)
+
+        serializer = AdminStudentListSerializer(page, many=True)
+        return paginator.get_paginated_response(serializer.data)

--- a/apps/users/views/admin_student_list_view.py
+++ b/apps/users/views/admin_student_list_view.py
@@ -1,26 +1,17 @@
 from typing import Never
 
-from django.db.models import Q
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
-from rest_framework.pagination import PageNumberPagination
 from rest_framework.request import Request
 from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
-from apps.users.models import User
 from apps.users.serializers.admin_student_list_serializer import (
     AdminStudentListSerializer,
 )
-
-
-# 페이지네이션
-class Pagination(PageNumberPagination):
-    page_size = 10
-    page_size_query_param = "page_size"
-    max_page_size = 100
+from apps.users.services.admin_atudent_list_service import get_student_list
 
 
 class AdminStudentListView(APIView):
@@ -32,13 +23,14 @@ class AdminStudentListView(APIView):
         raise PermissionDenied("권한이 없습니다.")
 
     @extend_schema(
-        tags=["admin_accounts"],
+        tags=["admin_students"],
         summary="어드민 페이지 수강생 목록 조회 API",
         description="관리자 권한을 가진 유저는 어드민 페이지 회원관리메뉴에서 등록된 수강생 목록 조회 가능",
         parameters=[
             OpenApiParameter(name="page", type=int, required=False),
             OpenApiParameter(name="page_size", type=int, required=False),
             OpenApiParameter(name="search", type=str, required=False),
+            OpenApiParameter(name="status", type=str, required=False, enum=["ACTIVATED", "DEACTIVATED", "WITHDREW"]),
         ],
         responses={
             200: AdminStudentListSerializer(many=True),
@@ -47,35 +39,10 @@ class AdminStudentListView(APIView):
         },
     )
     def get(self, request: Request) -> Response:
-        queryset = User.objects.prefetch_related("cohort_students__cohort__course", "withdrawal").order_by("id")
-
-        # 검색 기능(이메일, 이름, 닉네임, 휴대폰번호)
-        search = request.query_params.get("search")
-        if search:
-            queryset = queryset.filter(
-                Q(email__icontains=search)
-                | Q(name__icontains=search)
-                | Q(nickname__icontains=search)
-                | Q(phone_number__icontains=search)
-            )
-
-        # 과정별 필터링
-        course_id = request.query_params.get("course_id")
-        if course_id:
-            queryset = queryset.filter(cohort_students__cohort__course_id=int(course_id)).distinct()
-
-        # 기수별 필터링
-        cohort_id = request.query_params.get("cohort_id")
-        if cohort_id:
-            queryset = queryset.filter(cohort_students__cohort_id=int(cohort_id)).distinct()
-
-        # 페이지네이션
-        paginator = Pagination()
-
         try:
-            page = paginator.paginate_queryset(queryset, request)
+            page, paginator = get_student_list(request)
         except Exception:
-            return Response({"detail": "유효하지 않은 페이지입니다."}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error_detail": "유효하지 않은 페이지입니다."}, status=status.HTTP_400_BAD_REQUEST)
 
         serializer = AdminStudentListSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)

--- a/apps/users/views/admin_student_list_view.py
+++ b/apps/users/views/admin_student_list_view.py
@@ -1,6 +1,7 @@
 from typing import Never
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -40,4 +41,5 @@ class AdminStudentListView(APIView):
     def get(self, request: Request) -> Response:
         page, paginator = get_student_list(request)
         serializer = AdminStudentListSerializer(page, many=True)
-        return paginator.get_paginated_response(serializer.data)
+        response = paginator.get_paginated_response(serializer.data)
+        return Response(response.data, status=status.HTTP_200_OK)

--- a/apps/users/views/admin_student_list_view.py
+++ b/apps/users/views/admin_student_list_view.py
@@ -1,7 +1,6 @@
 from typing import Never
 
 from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
-from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
 from rest_framework.response import Response
@@ -39,10 +38,6 @@ class AdminStudentListView(APIView):
         },
     )
     def get(self, request: Request) -> Response:
-        try:
-            page, paginator = get_student_list(request)
-        except Exception:
-            return Response({"error_detail": "유효하지 않은 페이지입니다."}, status=status.HTTP_400_BAD_REQUEST)
-
+        page, paginator = get_student_list(request)
         serializer = AdminStudentListSerializer(page, many=True)
         return paginator.get_paginated_response(serializer.data)


### PR DESCRIPTION
## ✅ PR 요약
- 작업 요약: 어드민 페이지 수강생 목록 조회 API 구현

## 📄 상세 내용
- [x] AdminStudentListView 구현 (검색, 과정/기수 필터링, 페이지네이션)
- [x] AdminStudentListSerializer 구현 

## 📸 스크린샷 
<img width="540" height="446" alt="스크린샷 2026-05-09 오전 1 30 39" src="https://github.com/user-attachments/assets/d395ad69-1ed7-42cb-939e-3f2ca96887ba" />

## 📸 내 정보 조회 position 필드 추가 후 스크린샷
<img width="508" height="302" alt="image" src="https://github.com/user-attachments/assets/fa514318-11ca-423c-b36d-cb09259855cb" />


## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).