### PR TITLE
✨ feat: 어드민 질의응답 삭제 API 구현

### DIFF
--- a/apps/qna/schemas/question_admin_schemas.py
+++ b/apps/qna/schemas/question_admin_schemas.py
@@ -1,0 +1,29 @@
+from drf_spectacular.utils import OpenApiParameter, OpenApiResponse, extend_schema
+
+from apps.qna.serializers.admin_question_serializers import (
+    AdminQuestionDeleteResponseSerializer,
+)
+
+# ── 어드민 질문 삭제 ──────────────────────────────────────────────────
+
+admin_question_delete_schema = extend_schema(
+    tags=["Admin - Qna"],
+    summary="어드민 질의응답 삭제",
+    description="관리자가 질의응답을 삭제합니다. 연관된 답변과 댓글도 함께 삭제됩니다.",
+    parameters=[
+        OpenApiParameter(
+            name="question_id",
+            type=int,
+            location=OpenApiParameter.PATH,
+            description="질문 ID",
+            required=True,
+        ),
+    ],
+    responses={
+        200: AdminQuestionDeleteResponseSerializer,
+        400: OpenApiResponse(description="유효하지 않은 삭제 요청입니다."),
+        401: OpenApiResponse(description="로그인이 필요합니다."),
+        403: OpenApiResponse(description="질의응답 삭제 권한이 없습니다."),
+        404: OpenApiResponse(description="삭제할 질문을 찾을 수 없습니다."),
+    },
+)

--- a/apps/qna/serializers/admin_question_serializers.py
+++ b/apps/qna/serializers/admin_question_serializers.py
@@ -31,6 +31,7 @@ class AdminQuestionListItemSerializer(serializers.Serializer[Any]):
     created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
 
+
 # ── 어드민 질문 삭제 ──────────────────────────────────────────────────
 
 

--- a/apps/qna/serializers/admin_question_serializers.py
+++ b/apps/qna/serializers/admin_question_serializers.py
@@ -30,3 +30,13 @@ class AdminQuestionListItemSerializer(serializers.Serializer[Any]):
     has_answer = serializers.BooleanField()
     created_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
     updated_at = serializers.DateTimeField(format="%Y-%m-%d %H:%M:%S")
+
+# ── 어드민 질문 삭제 ──────────────────────────────────────────────────
+
+
+class AdminQuestionDeleteResponseSerializer(serializers.Serializer[Any]):
+    """어드민 질문 삭제 응답"""
+
+    question_id = serializers.IntegerField()
+    deleted_answer_count = serializers.IntegerField()
+    deleted_comment_count = serializers.IntegerField()

--- a/apps/qna/services/admin_question_services.py
+++ b/apps/qna/services/admin_question_services.py
@@ -1,9 +1,8 @@
-from django.db.models import Exists, OuterRef, Prefetch
+from django.db.models import Count, QuerySet
 
 from apps.qna.exceptions import NotFoundException
-from apps.qna.models.answer_models import Answer, AnswerComment
 from apps.qna.models.question_models import Question, QuestionCategory
-from apps.users.models import CohortStudents, User
+
 
 def _get_category_path(category: QuestionCategory) -> str:
     """카테고리 대/중/소를 ' > ' 로 연결한 문자열 반환"""
@@ -90,6 +89,8 @@ class AdminQuestionListService:
             "created_at": question.created_at,
             "updated_at": question.updated_at,
         }
+
+
 class AdminQuestionDeleteService:
     """어드민 질문 삭제 서비스"""
 

--- a/apps/qna/services/admin_question_services.py
+++ b/apps/qna/services/admin_question_services.py
@@ -1,7 +1,9 @@
-from django.db.models import Count, OuterRef, QuerySet, Subquery
+from django.db.models import Exists, OuterRef, Prefetch
 
-from apps.qna.models.question_models import Question, QuestionCategory, QuestionImage
-
+from apps.qna.exceptions import NotFoundException
+from apps.qna.models.answer_models import Answer, AnswerComment
+from apps.qna.models.question_models import Question, QuestionCategory
+from apps.users.models import CohortStudents, User
 
 def _get_category_path(category: QuestionCategory) -> str:
     """카테고리 대/중/소를 ' > ' 로 연결한 문자열 반환"""
@@ -87,4 +89,32 @@ class AdminQuestionListService:
             "has_answer": question.answer_count > 0,  # type: ignore[attr-defined]
             "created_at": question.created_at,
             "updated_at": question.updated_at,
+        }
+class AdminQuestionDeleteService:
+    """어드민 질문 삭제 서비스"""
+
+    @staticmethod
+    def delete_admin_question(question_id: int) -> dict[str, object]:
+        """어드민 질문 삭제 (답변, 댓글 포함)"""
+        try:
+            question = Question.objects.get(pk=question_id)
+        except Question.DoesNotExist:
+            raise NotFoundException("삭제할 질문을 찾을 수 없습니다.")
+
+        # 삭제 전 카운트 계산
+        deleted_answer_count = 0
+        deleted_comment_count = 0
+
+        # 각 답변의 댓글 수 계산 및 합산
+        for answer in question.answer_set.all():
+            deleted_comment_count += answer.answercomment_set.count()
+            deleted_answer_count += 1
+
+        # 질문 삭제 (cascade로 답변, 댓글, 이미지 모두 삭제됨)
+        question.delete()
+
+        return {
+            "question_id": question_id,
+            "deleted_answer_count": deleted_answer_count,
+            "deleted_comment_count": deleted_comment_count,
         }

--- a/apps/qna/tests/test_questions/test_admin_questions_delete.py
+++ b/apps/qna/tests/test_questions/test_admin_questions_delete.py
@@ -1,0 +1,275 @@
+from rest_framework import status
+from rest_framework.test import APIClient, APITestCase
+
+from apps.qna.models.answer_models import Answer, AnswerComment
+from apps.qna.models.question_models import Question, QuestionCategory, QuestionImage
+from apps.users.models import User
+
+
+class AdminQuestionDeleteAPIViewTest(APITestCase):
+    """DELETE /api/v1/admin/qna/questions/{question_id} - 어드민 질문 삭제 API 테스트"""
+
+    # 타입 어노테이션
+    admin_user: User
+    student_user: User
+    general_user: User
+    large_category: QuestionCategory
+    medium_category: QuestionCategory
+    small_category: QuestionCategory
+    question: Question
+    question_img1: QuestionImage
+    answer1: Answer
+    answer2: Answer
+    comment1: AnswerComment
+    comment2: AnswerComment
+    comment3: AnswerComment
+
+    @classmethod
+    def setUpTestData(cls) -> None:
+        # 어드민 유저
+        cls.admin_user = User.objects.create_user(
+            email="admin@test.com",
+            password="password123!",
+            name="어드민",
+            nickname="관리자",
+            phone_number="010-1111-1111",
+            gender="male",
+            birthday="1990-01-01",
+            role="ADMIN",
+            is_active=True,
+        )
+
+        # 학생 유저
+        cls.student_user = User.objects.create_user(
+            email="student@test.com",
+            password="password123!",
+            name="학생",
+            nickname="학생1",
+            phone_number="010-2222-2222",
+            gender="female",
+            birthday="2000-01-01",
+            role="STUDENT",
+            is_active=True,
+        )
+
+        # 일반 유저
+        cls.general_user = User.objects.create_user(
+            email="general@test.com",
+            password="password123!",
+            name="일반유저",
+            nickname="일반인",
+            phone_number="010-3333-3333",
+            gender="male",
+            birthday="1995-01-01",
+            role="GENERAL",
+            is_active=True,
+        )
+
+        # 카테고리 생성
+        cls.large_category = QuestionCategory.objects.create(name="백엔드", parent=None)
+        cls.medium_category = QuestionCategory.objects.create(name="Django", parent=cls.large_category)
+        cls.small_category = QuestionCategory.objects.create(name="ORM", parent=cls.medium_category)
+
+        # 질문 생성
+        cls.question = Question.objects.create(
+            author=cls.student_user,
+            category=cls.small_category,
+            title="Django ORM 질문",
+            content="ORM 관련 질문입니다.",
+        )
+
+        # 질문 이미지
+        cls.question_img1 = QuestionImage.objects.create(question=cls.question, img_url="https://example.com/img1.jpg")
+
+        # 답변 생성
+        cls.answer1 = Answer.objects.create(
+            author=cls.admin_user,
+            question=cls.question,
+            content="첫 번째 답변입니다.",
+            is_adopted=True,
+        )
+
+        cls.answer2 = Answer.objects.create(
+            author=cls.student_user,
+            question=cls.question,
+            content="두 번째 답변입니다.",
+            is_adopted=False,
+        )
+
+        # 댓글 생성
+        cls.comment1 = AnswerComment.objects.create(
+            author=cls.student_user,
+            answer=cls.answer1,
+            content="첫 번째 답변의 댓글 1",
+        )
+
+        cls.comment2 = AnswerComment.objects.create(
+            author=cls.admin_user,
+            answer=cls.answer1,
+            content="첫 번째 답변의 댓글 2",
+        )
+
+        cls.comment3 = AnswerComment.objects.create(
+            author=cls.student_user,
+            answer=cls.answer2,
+            content="두 번째 답변의 댓글 1",
+        )
+
+    def setUp(self) -> None:
+        self.client = APIClient()
+
+    # ── 정상 케이스 ──────────────────────────────────────────────────
+
+    def test_어드민_질문_삭제_성공(self) -> None:
+        """어드민 질문 삭제 성공"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = f"/api/v1/admin/qna/questions/{self.question.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        # 응답 확인
+        self.assertEqual(data["question_id"], self.question.id)
+        self.assertEqual(data["deleted_answer_count"], 2)
+        self.assertEqual(data["deleted_comment_count"], 3)
+
+        # 실제 삭제 확인
+        self.assertFalse(Question.objects.filter(id=self.question.id).exists())
+        self.assertFalse(Answer.objects.filter(question_id=self.question.id).exists())
+        self.assertFalse(QuestionImage.objects.filter(question_id=self.question.id).exists())
+        self.assertFalse(AnswerComment.objects.filter(answer__question_id=self.question.id).exists())
+
+    def test_답변_없는_질문_삭제(self) -> None:
+        """답변이 없는 질문 삭제"""
+        question_no_answer = Question.objects.create(
+            author=self.student_user,
+            category=self.small_category,
+            title="답변 없는 질문",
+            content="답변이 없습니다.",
+        )
+
+        self.client.force_authenticate(user=self.admin_user)
+        url = f"/api/v1/admin/qna/questions/{question_no_answer.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["deleted_answer_count"], 0)
+        self.assertEqual(data["deleted_comment_count"], 0)
+        self.assertFalse(Question.objects.filter(id=question_no_answer.id).exists())
+
+    def test_댓글_없는_질문_삭제(self) -> None:
+        """댓글이 없는 질문 삭제"""
+        question_no_comment = Question.objects.create(
+            author=self.student_user,
+            category=self.small_category,
+            title="댓글 없는 질문",
+            content="댓글이 없습니다.",
+        )
+
+        answer_no_comment = Answer.objects.create(
+            author=self.admin_user,
+            question=question_no_comment,
+            content="댓글 없는 답변",
+        )
+
+        self.client.force_authenticate(user=self.admin_user)
+        url = f"/api/v1/admin/qna/questions/{question_no_comment.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+
+        self.assertEqual(data["deleted_answer_count"], 1)
+        self.assertEqual(data["deleted_comment_count"], 0)
+
+    # ── 에러 케이스 ──────────────────────────────────────────────────
+
+    def test_존재하지_않는_질문_삭제_404(self) -> None:
+        """존재하지 않는 질문 삭제 시 404"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = "/api/v1/admin/qna/questions/99999"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+        self.assertEqual(response.json()["error_detail"], "삭제할 질문을 찾을 수 없습니다.")
+
+    def test_유효하지_않은_question_id_400(self) -> None:
+        """유효하지 않은 question_id 400"""
+        self.client.force_authenticate(user=self.admin_user)
+        url = "/api/v1/admin/qna/questions/0"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertEqual(response.json()["error_detail"], "유효하지 않은 삭제 요청입니다.")
+
+    # ── 권한 테스트 ──────────────────────────────────────────────────
+
+    def test_비로그인_사용자_401(self) -> None:
+        """비로그인 사용자 접근 불가"""
+        url = f"/api/v1/admin/qna/questions/{self.question.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+        # 삭제되지 않았는지 확인
+        self.assertTrue(Question.objects.filter(id=self.question.id).exists())
+
+    def test_STUDENT_권한_사용자_403(self) -> None:
+        """STUDENT 권한 사용자 접근 불가"""
+        self.client.force_authenticate(user=self.student_user)
+        url = f"/api/v1/admin/qna/questions/{self.question.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # 삭제되지 않았는지 확인
+        self.assertTrue(Question.objects.filter(id=self.question.id).exists())
+
+    def test_GENERAL_권한_사용자_403(self) -> None:
+        """GENERAL 권한 사용자 접근 불가"""
+        self.client.force_authenticate(user=self.general_user)
+        url = f"/api/v1/admin/qna/questions/{self.question.id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN)
+
+        # 삭제되지 않았는지 확인
+        self.assertTrue(Question.objects.filter(id=self.question.id).exists())
+
+    def test_CASCADE_삭제_확인(self) -> None:
+        """질문 삭제 시 연관 데이터 모두 삭제되는지 확인"""
+        # 삭제 전 개수 확인
+        question_id = self.question.id
+        self.assertEqual(Answer.objects.filter(question_id=question_id).count(), 2)
+        self.assertEqual(QuestionImage.objects.filter(question_id=question_id).count(), 1)
+        self.assertEqual(
+            AnswerComment.objects.filter(answer__question_id=question_id).count(),
+            3,
+        )
+
+        self.client.force_authenticate(user=self.admin_user)
+        url = f"/api/v1/admin/qna/questions/{question_id}"
+
+        response = self.client.delete(url)
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+
+        # CASCADE로 모두 삭제되었는지 확인
+        self.assertEqual(Question.objects.filter(id=question_id).count(), 0)
+        self.assertEqual(Answer.objects.filter(question_id=question_id).count(), 0)
+        self.assertEqual(QuestionImage.objects.filter(question_id=question_id).count(), 0)
+        self.assertEqual(
+            AnswerComment.objects.filter(answer__question_id=question_id).count(),
+            0,
+        )

--- a/apps/qna/urls/admin_urls.py
+++ b/apps/qna/urls/admin_urls.py
@@ -5,8 +5,10 @@ from apps.qna.views.admin_category_views import (
     AdminCategoryDestroyAPIView,
     AdminCategoryListCreateAPIView,
 )
-from apps.qna.views.admin_question_views import AdminQuestionListAPIView
-from apps.qna.views.admin_question_views import AdminQuestionDetailAPIView
+from apps.qna.views.admin_question_views import (
+    AdminQuestionDetailAPIView,
+    AdminQuestionListAPIView,
+)
 
 urlpatterns = [
     # 어드민 카테고리

--- a/apps/qna/urls/admin_urls.py
+++ b/apps/qna/urls/admin_urls.py
@@ -6,6 +6,7 @@ from apps.qna.views.admin_category_views import (
     AdminCategoryListCreateAPIView,
 )
 from apps.qna.views.admin_question_views import AdminQuestionListAPIView
+from apps.qna.views.admin_question_views import AdminQuestionDetailAPIView
 
 urlpatterns = [
     # 어드민 카테고리
@@ -15,7 +16,9 @@ urlpatterns = [
         name="admin-category-list-create",
     ),
     path("categories/<int:category_id>", AdminCategoryDestroyAPIView.as_view(), name="admin-category-delete"),
+    # 어드민 답변
     path("answers/<int:answer_id>", AdminAnswerDeleteView.as_view(), name="admin-answer-delete"),
     # 어드민 질의응답
     path("questions", AdminQuestionListAPIView.as_view(), name="admin-question-list"),
+    path("questions/<int:question_id>", AdminQuestionDetailAPIView.as_view(), name="admin-question-detail"),
 ]

--- a/apps/qna/views/admin_question_views.py
+++ b/apps/qna/views/admin_question_views.py
@@ -1,5 +1,7 @@
 from typing import NoReturn
 
+from typing import Any
+
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
 from rest_framework.request import Request
@@ -8,11 +10,15 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
 from apps.qna.models.question_models import QuestionCategory
+from apps.qna.exceptions import BaseCustomException
+from apps.qna.schemas.question_admin_schemas import admin_question_delete_schema
 from apps.qna.serializers.admin_question_serializers import (
     AdminQuestionListItemSerializer,
     AdminQuestionListQuerySerializer,
+    AdminQuestionDeleteResponseSerializer,
 )
 from apps.qna.services.admin_question_services import AdminQuestionListService
+from apps.qna.services.admin_question_services import AdminQuestionDeleteService
 
 
 class AdminQuestionListAPIView(APIView):
@@ -60,3 +66,27 @@ class AdminQuestionListAPIView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+class AdminQuestionDetailAPIView(APIView):
+    """어드민 질문 상세 조회/삭제 API"""
+
+    permission_classes = [IsRoleAdminUser]
+
+    @admin_question_delete_schema
+    def delete(self, request: Request, question_id: int, *args: Any, **kwargs: Any) -> Response:
+        """어드민 질문 삭제"""
+        # question_id 유효성 검사
+        if not isinstance(question_id, int) or question_id < 1:
+            return Response(
+                {"error_detail": "유효하지 않은 삭제 요청입니다."},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        try:
+            result = AdminQuestionDeleteService.delete_admin_question(question_id)
+            serializer = AdminQuestionDeleteResponseSerializer(result)
+            return Response(serializer.data, status=status.HTTP_200_OK)
+        except BaseCustomException as e:
+            return Response(
+                {"error_detail": e.message},
+                status=e.status_code,
+            )

--- a/apps/qna/views/admin_question_views.py
+++ b/apps/qna/views/admin_question_views.py
@@ -1,6 +1,4 @@
-from typing import NoReturn
-
-from typing import Any
+from typing import Any, NoReturn
 
 from rest_framework import status
 from rest_framework.exceptions import NotAuthenticated, PermissionDenied
@@ -9,16 +7,18 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
-from apps.qna.models.question_models import QuestionCategory
 from apps.qna.exceptions import BaseCustomException
+from apps.qna.models.question_models import QuestionCategory
 from apps.qna.schemas.question_admin_schemas import admin_question_delete_schema
 from apps.qna.serializers.admin_question_serializers import (
+    AdminQuestionDeleteResponseSerializer,
     AdminQuestionListItemSerializer,
     AdminQuestionListQuerySerializer,
-    AdminQuestionDeleteResponseSerializer,
 )
-from apps.qna.services.admin_question_services import AdminQuestionListService
-from apps.qna.services.admin_question_services import AdminQuestionDeleteService
+from apps.qna.services.admin_question_services import (
+    AdminQuestionDeleteService,
+    AdminQuestionListService,
+)
 
 
 class AdminQuestionListAPIView(APIView):
@@ -66,10 +66,26 @@ class AdminQuestionListAPIView(APIView):
             },
             status=status.HTTP_200_OK,
         )
+
+
 class AdminQuestionDetailAPIView(APIView):
     """어드민 질문 상세 조회/삭제 API"""
 
     permission_classes = [IsRoleAdminUser]
+
+    def permission_denied(self, request: Request, message: str | None = None, code: str | None = None) -> NoReturn:
+        """권한 에러 처리"""
+        # 401: 비로그인
+        if not request.user.is_authenticated:
+            raise NotAuthenticated(detail="로그인이 필요합니다.")
+
+        # 403: 권한 없음 (HTTP 메서드에 따라 메시지 구분)
+        if request.method == "GET":
+            raise PermissionDenied(detail="질의응답 상세 조회 권한이 없습니다.")
+        elif request.method == "DELETE":
+            raise PermissionDenied(detail="질의응답 삭제 권한이 없습니다.")
+        else:
+            raise PermissionDenied(detail="권한이 없습니다.")
 
     @admin_question_delete_schema
     def delete(self, request: Request, question_id: int, *args: Any, **kwargs: Any) -> Response:


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: ✨ feat: 어드민 질의응답 삭제 API 구현

## 📄 상세 내용
- [ ] 어드민 질의응답 삭제 API 구현
- [ ] 테스트 코드
- [ ] 주요 변경 사항 3

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [ ] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [ ] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
