### PR TITLE
♻️ refactor: Subject serializer, service, view 코드 개선

### DIFF
--- a/apps/courses/serializers/subject_serializer.py
+++ b/apps/courses/serializers/subject_serializer.py
@@ -14,7 +14,7 @@ class SubjectCourseSerializer(serializers.ModelSerializer[Course]):
 
 
 class SubjectListSerializer(serializers.ModelSerializer[Subject]):
-    course_id = serializers.IntegerField()
+    course_id = serializers.IntegerField(read_only=True)
     status = serializers.SerializerMethodField()
 
     class Meta:

--- a/apps/courses/services/subject_service.py
+++ b/apps/courses/services/subject_service.py
@@ -45,14 +45,10 @@ def get_subject_detail(subject_id: int) -> Subject:
     try:
         return Subject.objects.select_related("course").get(id=subject_id)
     except Subject.DoesNotExist:
-        raise SubjectNotFoundError("해당 과목을 찾을 수 없습니다.")
-
-
-def update_subject(subject_id: int, **kwargs: Any) -> Subject:
-    try:
-        subject = Subject.objects.select_related("course").get(id=subject_id)
-    except Subject.DoesNotExist:
         raise SubjectNotFoundError()
+
+
+def update_subject(subject: Subject, **kwargs: Any) -> Subject:
     for attr, value in kwargs.items():
         setattr(subject, attr, value)
     try:

--- a/apps/courses/views/subject_view.py
+++ b/apps/courses/views/subject_view.py
@@ -106,7 +106,7 @@ class SubjectDetailView(APIView):
     )
     def get(self, request: Request, subject_id: int) -> Response:
         subject = subject_service.get_subject_detail(subject_id=subject_id)
-        return Response(SubjectDetailSerializer(subject).data)
+        return Response(SubjectDetailSerializer(subject).data, status=status.HTTP_200_OK)
 
     @extend_schema(
         tags=["Admin - Subject"],
@@ -125,7 +125,7 @@ class SubjectDetailView(APIView):
         serializer = SubjectUpdateSerializer(instance=subject, data=request.data, partial=True)
         if not serializer.is_valid():
             return Response({"error_detail": "유효하지 않은 데이터입니다."}, status=status.HTTP_400_BAD_REQUEST)
-        subject = subject_service.update_subject(subject_id=subject_id, **serializer.validated_data)
+        subject = subject_service.update_subject(subject, **serializer.validated_data)
         return Response(SubjectUpdateSerializer(subject).data, status=status.HTTP_200_OK)
 
     @extend_schema(


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: #123
- 작업 요약: 어떤 작업을 했는지 간단하게 적어주세요.

## 📄 상세 내용
- [ ] subject_service.py: update_subject 중복 DB 조회 제거 (subject 인스턴스 직접 수신)
- [ ] subject_serializer.py: SubjectListSerializer course_id read_only=True 추가
- [ ] subject_view.py: SubjectDetailView.get 응답에 status 코드 누락 (get만 누락되서 추가)
- [ ] subject_view.py: exceptions.py에서 커스텀에러를 호출해서 사용하는데, get_subject_detail에서 중복 메시지 제거

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
