### PR TITLE
feature/exams exam - 400 에러메시지 수정

### DIFF
--- a/apps/exams/exceptions/exam_exception.py
+++ b/apps/exams/exceptions/exam_exception.py
@@ -11,3 +11,18 @@ class SubjectNotFound(Exception):
 class ExamDeleteConflict(Exception):
     def __init__(self, message: str = "쪽지시험 삭제 중 충돌이 발생했습니다."):
         super().__init__(message)
+
+
+class CreateBadRequest(Exception):
+    def __init__(self, message: str = "유효하지 않은 시험 생성 요청입니다."):
+        super().__init__(message)
+
+
+class ExamBadRequest(Exception):
+    def __init__(self, message: str = "유효하지 않은 요청입니다."):
+        super().__init__(message)
+
+
+class ExamDataBadRequest(Exception):
+    def __init__(self, message: str = "유효하지 않은 요청 데이터입니다."):
+        super().__init__(message)

--- a/apps/exams/serializers/admin_exam_serializer.py
+++ b/apps/exams/serializers/admin_exam_serializer.py
@@ -107,10 +107,6 @@ class ExamErrorSerializer(serializers.Serializer[Any]):
     error_detail = serializers.CharField()
 
 
-class ExamValidationErrorSerializer(serializers.Serializer[Any]):
-    error_detail = serializers.DictField()
-
-
 class ExamDeleteResponseSerializer(serializers.Serializer[Any]):
     id = serializers.IntegerField()
 

--- a/apps/exams/serializers/user_exam_submission_serializer.py
+++ b/apps/exams/serializers/user_exam_submission_serializer.py
@@ -1,5 +1,5 @@
 from typing import Any
-
+import json
 from rest_framework import serializers
 
 from apps.exams.models import Exam, ExamQuestion, ExamSubmission
@@ -13,9 +13,12 @@ class ExamNestedSerializer(serializers.ModelSerializer[Exam]):
 
 
 class QuestionsNestedSerializer(serializers.ModelSerializer[ExamQuestion]):
-    options = serializers.JSONField(required=False, source="options_json")
+    options = serializers.SerializerMethodField()
     is_correct = serializers.SerializerMethodField()
     submitted_answer = serializers.SerializerMethodField()
+
+    def get_options(self, obj: ExamQuestion) -> list[str] | None:
+        return json.loads(obj.options_json) if obj.options_json else None
 
     def get_is_correct(self, obj: ExamQuestion) -> bool:
         answer_json: dict[str, list[str]] = self.context.get("answer_json", {})

--- a/apps/exams/serializers/user_exam_submission_serializer.py
+++ b/apps/exams/serializers/user_exam_submission_serializer.py
@@ -1,5 +1,6 @@
-from typing import Any
 import json
+from typing import Any
+
 from rest_framework import serializers
 
 from apps.exams.models import Exam, ExamQuestion, ExamSubmission

--- a/apps/exams/services/admin_exam_service.py
+++ b/apps/exams/services/admin_exam_service.py
@@ -47,6 +47,10 @@ def get_exam_list(
         submit_count=Count("examdeployment__examsubmission", distinct=True),
     )
 
+    if order and not sort:
+        ordering = "created_at" if order == "asc" else "-created_at"
+        queryset = queryset.order_by(ordering)
+
     if sort and sort in ALLOWED_SORT_FIELDS:
         ordering = f"-{sort}" if order == "desc" else sort
         queryset = queryset.order_by(ordering)

--- a/apps/exams/tests/test_admin_exam.py
+++ b/apps/exams/tests/test_admin_exam.py
@@ -185,6 +185,7 @@ class TestExamAPI(ExamBaseTestCase):
         response = self.client.get(reverse("exam-list"), {"subject_id": "text"})
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_detail"], "유효하지 않은 요청입니다.")
 
     # 쪽지시험 목록 조회: 검색
     def test_get_exam_list_with_search_title(self) -> None:
@@ -388,6 +389,7 @@ class TestExamAPI(ExamBaseTestCase):
             format="json",
         )
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_detail"], "유효하지 않은 시험 생성 요청입니다.")
         self.assertEqual(Exam.objects.count(), 2)
 
     def test_exam_create_title_max_length(self) -> None:
@@ -403,6 +405,7 @@ class TestExamAPI(ExamBaseTestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_detail"], "유효하지 않은 시험 생성 요청입니다.")
         self.assertEqual(Exam.objects.count(), 2)
 
 
@@ -559,6 +562,7 @@ class TestExamDetail(ExamBaseTestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_detail"], "유효하지 않은 요청 데이터입니다.")
         self.assertEqual(Exam.objects.count(), 2)
 
     def test_detail_put_title_max_langth(self) -> None:
@@ -573,6 +577,7 @@ class TestExamDetail(ExamBaseTestCase):
         )
 
         self.assertEqual(response.status_code, 400)
+        self.assertEqual(response.data["error_detail"], "유효하지 않은 요청 데이터입니다.")
         self.assertEqual(Exam.objects.count(), 2)
 
     # 쪽지시험 삭제: 권한

--- a/apps/exams/views/admin_exam_view.py
+++ b/apps/exams/views/admin_exam_view.py
@@ -15,6 +15,9 @@ from rest_framework.views import APIView
 
 from apps.core.utils.permissions import IsRoleAdminUser
 from apps.exams.exceptions.exam_exception import (
+    CreateBadRequest,
+    ExamBadRequest,
+    ExamDataBadRequest,
     ExamDeleteConflict,
     ExamTitleConflict,
     SubjectNotFound,
@@ -27,7 +30,6 @@ from apps.exams.serializers.admin_exam_serializer import (
     ExamListQuerySerializer,
     ExamListSerializer,
     ExamPageResponseSerializer,
-    ExamValidationErrorSerializer,
 )
 from apps.exams.services.admin_exam_service import (
     create_exam,
@@ -113,14 +115,16 @@ class ExamListCreateView(APIView):
         ],
         responses={
             200: ExamPageResponseSerializer,
-            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
-            403: OpenApiResponse(description="쪽지시험 목록 조회 권한이 없습니다."),
+            400: OpenApiResponse(description="유효하지 않은 요청입니다.", response=ExamErrorSerializer),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다.", response=ExamErrorSerializer),
+            403: OpenApiResponse(description="쪽지시험 목록 조회 권한이 없습니다.", response=ExamErrorSerializer),
         },
     )
     def get(self, request: Request) -> Response:
         query_serializer = ExamListQuerySerializer(data=request.query_params)
         if not query_serializer.is_valid():
-            return Response({"error_detail": query_serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+            e = ExamBadRequest()
+            return Response({"error_detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
         queryset = get_exam_list(
             subject_id=query_serializer.validated_data.get("subject_id"),
@@ -142,19 +146,20 @@ class ExamListCreateView(APIView):
             201: ExamCreatePutSerializer,
             400: OpenApiResponse(
                 description="유효하지 않은 시험 생성 요청입니다.",
-                response=ExamValidationErrorSerializer,
+                response=ExamErrorSerializer,
             ),
-            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
-            403: OpenApiResponse(description="쪽지시험 생성 권한이 없습니다."),
-            404: OpenApiResponse(description="해당 과목 정보를 찾을 수 없습니다."),
-            409: OpenApiResponse(description="동일한 이름의 시험이 이미 존재합니다."),
+            401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다.", response=ExamErrorSerializer),
+            403: OpenApiResponse(description="쪽지시험 생성 권한이 없습니다.", response=ExamErrorSerializer),
+            404: OpenApiResponse(description="해당 과목 정보를 찾을 수 없습니다.", response=ExamErrorSerializer),
+            409: OpenApiResponse(description="동일한 이름의 시험이 이미 존재합니다.", response=ExamErrorSerializer),
         },
     )
     def post(self, request: Request) -> Response:
         try:
             serializer = ExamCreatePutSerializer(data=request.data, context={"request": request})
             if not serializer.is_valid():
-                return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+                e = CreateBadRequest()
+                return Response({"error_detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
 
             exam = create_exam(**serializer.validated_data)
         except ExamTitleConflict as e:
@@ -184,7 +189,7 @@ class ExamDetailView(APIView):
         summary="쪽지 시험 상세 조회",
         responses={
             200: ExamDetailSerializer,
-            401: ExamErrorSerializer,
+            401: OpenApiResponse(response=ExamErrorSerializer, description="자격 인증 데이터가 제공되지 않았습니다."),
             403: OpenApiResponse(response=ExamErrorSerializer, description="쪽지시험 상세 조회 권한이 없습니다."),
             404: OpenApiResponse(response=ExamErrorSerializer, description="해당 쪽지시험 정보를 찾을 수 없습니다."),
         },
@@ -206,7 +211,7 @@ class ExamDetailView(APIView):
             200: ExamCreatePutSerializer,
             400: OpenApiResponse(
                 description="유효하지 않은 요청 데이터입니다.",
-                response=ExamValidationErrorSerializer,
+                response=ExamErrorSerializer,
             ),
             401: OpenApiResponse(description="자격 인증 데이터가 제공되지 않았습니다."),
             403: OpenApiResponse(description="쪽지시험 수정 권한이 없습니다."),
@@ -224,7 +229,8 @@ class ExamDetailView(APIView):
         try:
             serializer = ExamCreatePutSerializer(data=request.data, context={"request": request})
             if not serializer.is_valid():
-                return Response({"error_detail": serializer.errors}, status=status.HTTP_400_BAD_REQUEST)
+                e = ExamDataBadRequest()
+                return Response({"error_detail": str(e)}, status=status.HTTP_400_BAD_REQUEST)
             exam = put_exam(exam_id=exam_id, **serializer.validated_data)
         except ExamTitleConflict as e:
             return Response({"error_detail": str(e)}, status=status.HTTP_409_CONFLICT)


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: 400 에러메시지 수정, list 조회 쿼리 파라미터 order 단독 사용할 수 있도록 수정
- 400 에러 메시지에 대한 테스트 추가
- 스웨거 tag 표시 변경 - user exam submission post / exams -> user-exams
- submission user 상세내역 조회 options 출력 버그 수정


## 📄 상세 내용
- 400 에러메시지 변경
- 400 에러 메시지 테스트 추가
- 쿼리 파라미터 order 단독 사용할 수 있도록 수정
- submission user 상세내역 조회 options 출력 버그 수정


## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
