### PR TITLE
Fix/qna/chatbot

### DIFF
--- a/apps/qna/redis/repositories.py
+++ b/apps/qna/redis/repositories.py
@@ -64,6 +64,6 @@ class CacheRepository:
         return f"{prefix}:{version}:" if prefix else f":{version}:"
 
     @staticmethod
-    def get_many(keys: list[str]) -> dict[str, str]:
+    def get_many(keys: list[str]) -> dict[str, Any]:
         raw_dict = cache.get_many(keys)
         return {k: json.loads(v) for k, v in raw_dict.items() if v is not None}

--- a/apps/qna/redis/repositories.py
+++ b/apps/qna/redis/repositories.py
@@ -29,7 +29,7 @@ class CacheRepository:
         return [Message(**m) for m in json.loads(cached)]
 
     @staticmethod
-    def save_history(key: str, history: list[dict[str, str]], ttl: int) -> None:
+    def save_history(key: str, history: list[dict[str, Any]], ttl: int) -> None:
         cache.set(key, json.dumps(history), timeout=ttl)
 
     @staticmethod
@@ -64,5 +64,6 @@ class CacheRepository:
         return f"{prefix}:{version}:" if prefix else f":{version}:"
 
     @staticmethod
-    def get_many(keys: list[str]) -> dict[str, Any]:
-        return cache.get_many(keys)
+    def get_many(keys: list[str]) -> dict[str, str]:
+        raw_dict = cache.get_many(keys)
+        return {k: json.loads(v) for k, v in raw_dict.items() if v is not None}

--- a/apps/qna/schemas/chatbot_schemas.py
+++ b/apps/qna/schemas/chatbot_schemas.py
@@ -1,6 +1,7 @@
 from drf_spectacular.utils import OpenApiResponse, extend_schema
 
 from apps.qna.serializers.chatbot_serializers import (
+    ChatbotRequestSerializer,
     HistoryResponseSerializer,
     InitialAIAnswerSerializer,
     QNAChatbotListResponseSerializer,
@@ -40,6 +41,7 @@ qna_chatbot_post_schema = extend_schema(
     tags=["chatbot"],
     summary="qna 챗봇 대화",
     description="활성화된 채팅창에서 qna 챗봇과 질의응답을 합니다.",
+    request=ChatbotRequestSerializer,
     responses={
         200: OpenApiResponse(description="SSE 스트림 (text/event-stream)"),
         401: OpenApiResponse(description="로그인한 사용자만 이용할 수 있습니다."),
@@ -89,6 +91,7 @@ cs_chatbot_post_schema = extend_schema(
     tags=["chatbot"],
     summary="cs 챗봇 대화",
     description="활성화된 채팅창에서 cs 챗봇에게 고객지원을 받습니다.",
+    request=ChatbotRequestSerializer,
     responses={
         200: OpenApiResponse(description="SSE 스트림 (text/event-stream)"),
     },

--- a/apps/qna/services/chatbot_qna.py
+++ b/apps/qna/services/chatbot_qna.py
@@ -1,3 +1,4 @@
+from dataclasses import asdict
 from typing import Iterator
 
 from apps.qna.chatbot import GROQ_MODEL, QNA_PROMPT, GroqPayloadFactory
@@ -50,7 +51,8 @@ class QNAChatbotService(ChatbotBaseService):
         keys = CacheRepository.get_qna_keys(user_id)
         qna_list = []
         for key, value in CacheRepository.get_many(keys).items():
-            qna_list.append(CacheFactory.create_last_qna(key, value))
+            if value:
+                qna_list.append(CacheFactory.create_last_qna(key, value))
 
         return qna_list
 
@@ -74,8 +76,13 @@ class QNAChatbotService(ChatbotBaseService):
     @staticmethod
     def _return_qna_history(user_id: int, question_id: int, initial: InitialQNA) -> list[Message]:
         QNAChatbotService._make_session(user_id, question_id)
-        history = CacheRepository.get_history(QNA_KEY.format(user_id=user_id, question_id=question_id))
-        return [Message(role="assistant", content=initial.answer), *(history or [])]
+        key = QNA_KEY.format(user_id=user_id, question_id=question_id)
+        history = CacheRepository.get_history(key)
+        if not history:
+            initial_message = Message(role="assistant", content=initial.answer, created_at=str(initial.created_at))
+            CacheRepository.save_history(key, [asdict(initial_message)], QNAChatbotService.QNA_TTL)
+            history = [initial_message]
+        return history
 
     @staticmethod
     def _make_session(user_id: int, question_id: int) -> None:

--- a/apps/qna/services/chatbot_qna.py
+++ b/apps/qna/services/chatbot_qna.py
@@ -51,8 +51,7 @@ class QNAChatbotService(ChatbotBaseService):
         keys = CacheRepository.get_qna_keys(user_id)
         qna_list = []
         for key, value in CacheRepository.get_many(keys).items():
-            if value:
-                qna_list.append(CacheFactory.create_last_qna(key, value))
+            qna_list.append(CacheFactory.create_last_qna(key, value))
 
         return qna_list
 

--- a/apps/qna/tests/test_chatbots/test_services/test_qna.py
+++ b/apps/qna/tests/test_chatbots/test_services/test_qna.py
@@ -1,4 +1,5 @@
 from dataclasses import asdict
+from typing import Any
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
@@ -68,6 +69,7 @@ class TestQNAChatbotService(IsolatedRedisTestClient):
 
     def test_response_qna_history_prepends_initial_to_existing_history(self) -> None:
         history = [
+            Message(role="assistant", content=self.initial.answer),  # 이니셜이 첫번째로
             Message(role="user", content="질문입니다."),
             Message(role="assistant", content="답변입니다."),
         ]
@@ -78,7 +80,7 @@ class TestQNAChatbotService(IsolatedRedisTestClient):
         )
         result = QNAChatbotService.response_qna_history(self.user_id, self.question_id)
         self.assertEqual(len(result), 3)
-        self.assertEqual(result[0].content, self.initial.answer)  # initial이 맨 앞
+        self.assertEqual(result[0].content, self.initial.answer)
         self.assertEqual(result[1].content, "질문입니다.")
 
     def test_make_qna_context_raises_403_when_session_invalid(self) -> None:
@@ -217,12 +219,12 @@ class TestGetQnaList(IsolatedRedisTestClient):
     def setUp(self) -> None:
         super().setUp()
         self.user_id = 1
-        self.value = [
+        self.value: list[dict[str, Any]] = [
             {"role": "user", "content": "질문입니다.", "created_at": None},
             {"role": "assistant", "content": "답변입니다.", "created_at": "2026-04-23T14:30:05"},
         ]
-        cache.set(f"qna_chat:{self.user_id}:42", self.value)
-        cache.set(f"qna_chat:{self.user_id}:55", self.value)
+        CacheRepository.save_history(f"qna_chat:{self.user_id}:42", self.value, ttl=1800)
+        CacheRepository.save_history(f"qna_chat:{self.user_id}:55", self.value, ttl=1800)
 
     def tearDown(self) -> None:
         super().tearDown()

--- a/apps/qna/tests/test_chatbots/test_views.py
+++ b/apps/qna/tests/test_chatbots/test_views.py
@@ -1,4 +1,4 @@
-from typing import Iterator, cast
+from typing import Any, Iterator, cast
 from unittest.mock import MagicMock, patch
 
 from django.core.cache import cache
@@ -282,12 +282,12 @@ class TestQNAChatbotListAPIView(IsolatedRedisTestClient):
 
     def setUp(self) -> None:
         super().setUp()
-        self.value = [
+        self.value: list[dict[str, Any]] = [
             {"role": "user", "content": "질문입니다.", "created_at": None},
             {"role": "assistant", "content": "답변입니다.", "created_at": "2026-04-23T14:30:05"},
         ]
-        cache.set(f"qna_chat:{self.user.id}:42", self.value)
-        cache.set(f"qna_chat:{self.user.id}:55", self.value)
+        CacheRepository.save_history(f"qna_chat:{self.user.id}:42", self.value, ttl=1800)
+        CacheRepository.save_history(f"qna_chat:{self.user.id}:55", self.value, ttl=1800)
 
     def tearDown(self) -> None:
         super().tearDown()


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 
- 작업 요약: qna 챗봇 리스트 조회 오류 수정 및 기능 추가

## 📄 상세 내용
- 리스트 조회 기능 중 잘못 파싱하고 있던 부분 수정
- qna 챗봇 히스토리 상세 조회를 한번 했다면 초기응답을 히스토리로 저장하는 기능 추가(없으면 리스트 조회 때 안 잡힘)

## 📸 스크린샷 (선택)

## 📝 기타 참고 사항

## 🧪 PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).
