### PR TITLE
Feature/exams deploy

### DIFF
--- a/apps/exams/serializers/user_exam_submission_serializer.py
+++ b/apps/exams/serializers/user_exam_submission_serializer.py
@@ -103,7 +103,7 @@ class AnswerItemSerializer(serializers.Serializer[Any]):
     type = serializers.ChoiceField(
         choices=["single_choice", "multiple_choice", "short_answer", "fill_blank", "ox", "ordering"]
     )
-    submitted_answer = serializers.JSONField(required=False, default=list)
+    submitted_answer = serializers.JSONField(required=False, default=list)  # type: ignore[arg-type]
 
 
 class UserExamSubmissionCreateSerializer(serializers.Serializer[Any]):

--- a/apps/exams/serializers/user_exam_submission_serializer.py
+++ b/apps/exams/serializers/user_exam_submission_serializer.py
@@ -103,7 +103,7 @@ class AnswerItemSerializer(serializers.Serializer[Any]):
     type = serializers.ChoiceField(
         choices=["single_choice", "multiple_choice", "short_answer", "fill_blank", "ox", "ordering"]
     )
-    submitted_answer = serializers.JSONField(required=False)
+    submitted_answer = serializers.JSONField(required=False, default=list)
 
 
 class UserExamSubmissionCreateSerializer(serializers.Serializer[Any]):

--- a/apps/exams/services/user_exam_submission_service.py
+++ b/apps/exams/services/user_exam_submission_service.py
@@ -10,7 +10,7 @@ from apps.exams.models import ExamDeployment, ExamSubmission
 
 def get_submission_detail(submitter: int, submission_id: int) -> ExamSubmission:
     try:
-        return ExamSubmission.objects.select_related("deployment__exam__subject").get(
+        return ExamSubmission.objects.select_related("deployment__exam").get(
             submitter=submitter, id=submission_id
         )
     except ExamSubmission.DoesNotExist:
@@ -38,7 +38,7 @@ def create_submission(submitter_id: int, validated_data: dict[str, Any]) -> Exam
 
     for answer in answers:
         q_id = str(answer["question_id"])
-        submitted = answer["submitted_answer"]
+        submitted = answer.get("submitted_answer") or []
         submitted_list = [submitted] if isinstance(submitted, str) else list(submitted)
         answer_json[q_id] = submitted_list
 

--- a/apps/exams/services/user_exam_submission_service.py
+++ b/apps/exams/services/user_exam_submission_service.py
@@ -10,9 +10,7 @@ from apps.exams.models import ExamDeployment, ExamSubmission
 
 def get_submission_detail(submitter: int, submission_id: int) -> ExamSubmission:
     try:
-        return ExamSubmission.objects.select_related("deployment__exam").get(
-            submitter=submitter, id=submission_id
-        )
+        return ExamSubmission.objects.select_related("deployment__exam").get(submitter=submitter, id=submission_id)
     except ExamSubmission.DoesNotExist:
         raise UserSubmissionNotFound()
 


### PR DESCRIPTION
## ✅ PR 요약
- 관련 이슈 번호: 없음
- 작업 요약: 쪽지시험 제출 API의 불필요한 DB 쿼리 최적화 및 submitted_answer 누락 시 발생하는 KeyError 방어 처리

## 📋 상세 내용
- [x] `get_submission_detail`: `select_related`에서 불필요한 `subject` JOIN 제거
  (`deployment__exam__subject` → `deployment__exam`)
- [x] `create_submission`: `answer["submitted_answer"]` → `answer.get("submitted_answer") or []` 로 변경하여 강제 제출 시 KeyError 및 TypeError 방지

## 🖼️ 스크린샷 (선택)

## 📝 기타 참고 사항
- `submitted_answer`가 없는 경우(강제 제출)는 빈 리스트로 처리되어 해당 문제는 오답 처리됩니다.

## ✏️ PR Checklist
- [x] 커밋 메시지 컨벤션에 맞게 작성했습니다.
- [x] 변경 사항에 대한 테스트를 했습니다.(버그 수정/기능에 대한 테스트).